### PR TITLE
feat(summary-bot): Issue/PR作成時にポエム調サマリーをbody先頭に自動追記

### DIFF
--- a/.github/workflows/summary-bot.yml
+++ b/.github/workflows/summary-bot.yml
@@ -2,9 +2,9 @@ name: Summary Bot
 
 on:
   issues:
-    types: [opened]
+    types: [opened, edited]
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 permissions:
   issues: write


### PR DESCRIPTION
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> 機械の心が言葉を紡ぎ、
> Issue と PR の始まりに詩を刻む。
> Claude の知恵が身軽く舞い、
> 技術の淵から美しき要約が湧き出づ。
> 二度と繰り返さぬ、優雅なる自動化。

---
<!-- summary-bot-end -->



（元のbody本文）
```

## 事前設定（完了済み）

- [x] `ANTHROPIC_API_KEY` を GitHub Secrets に登録済み

## Test plan

- [ ] このPRをマージ後、新規Issueを作成して動作確認
- [ ] 新規PRを作成して動作確認
- [ ] body先頭にポエムサマリーが追記されることを確認
- [ ] 二重書き込みされないことを確認（editedイベントが来ても再追記しない）

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)