### PR TITLE
feat(gantt): Open時にTarget dateを+14日で仮セット

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -70,6 +70,27 @@ git add <files>     # 個別ファイル指定（推奨）
 git commit          # pre-commitフックが自動実行（P1実装後）
 ```
 
+### PR作成ルール（BLOCKING REQUIREMENT）
+
+**PR bodyには必ず対応するISSUE番号を `Closes #XX` で記載する。**
+
+```markdown
+## Summary
+...
+
+Closes #XX  ← 必須。これがないとISSUEが自動Closeされない。
+```
+
+**理由**:
+- PRマージ時にGitHubがISSUEを自動Close
+- ガントチャートの `Target date` が自動セットされる（gantt-auto-dates workflow）
+- 振り返り時にPR↔ISSUE の対応が追える
+
+**NGパターン**:
+```markdown
+# #40 のリンクをbodyに書かない → ISSUEがCloseされず、Target dateがセットされない
+```
+
 ---
 
 ## テスト

--- a/.github/workflows/gantt-auto-dates.yml
+++ b/.github/workflows/gantt-auto-dates.yml
@@ -38,13 +38,16 @@ jobs:
           echo "item_id=$ITEM_ID" >> $GITHUB_OUTPUT
           echo "Found item ID: $ITEM_ID"
 
-      - name: Set Start date on issue open
+      - name: Set Start date and provisional Target date on issue open
         if: github.event.action == 'opened' && steps.get-item.outputs.item_id != ''
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           TODAY=$(date -u +%Y-%m-%d)
-          echo "Setting Start date to $TODAY for item ${{ steps.get-item.outputs.item_id }}"
+          TARGET=$(date -u -d "+14 days" +%Y-%m-%d 2>/dev/null || date -u -v+14d +%Y-%m-%d)
+          echo "Setting Start date to $TODAY, provisional Target date to $TARGET"
+
+          # Start date をセット
           gh api graphql -f query='
             mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
               updateProjectV2ItemFieldValue(input: {
@@ -61,6 +64,24 @@ jobs:
           -f itemId="${{ steps.get-item.outputs.item_id }}" \
           -f fieldId="PVTF_lAHOAAnM1c4BPcBdzg92YI8" \
           -f date="$TODAY"
+
+          # Target date を仮セット（+14日）
+          gh api graphql -f query='
+            mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $date: Date!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $projectId
+                itemId: $itemId
+                fieldId: $fieldId
+                value: { date: $date }
+              }) {
+                projectV2Item { id }
+              }
+            }
+          ' \
+          -f projectId="PVT_kwHOAAnM1c4BPcBd" \
+          -f itemId="${{ steps.get-item.outputs.item_id }}" \
+          -f fieldId="PVTF_lAHOAAnM1c4BPcBdzg92YJA" \
+          -f date="$TARGET"
 
       - name: Set Target date on issue close
         if: github.event.action == 'closed' && steps.get-item.outputs.item_id != ''


### PR DESCRIPTION
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> 課題の扉開くとき、14日先へ希望を仮置く、
> Start dateは今この瞬間に、Target dateは彼方の約束に。
> Close時に現在が確定され、バーは真の長さを得る。
> Open中のISSUEも、ロードマップに淡き光の軌跡を描く。

---
<!-- summary-bot-end -->

## Summary
- ISSUE Open時に `Start date` = 今日 + `Target date` = 今日+14日（仮）を同時セット
- ISSUE Close時に `Target date` = 今日（確定）で上書き
- Open中のISSUEもロードマップにバーが表示されるようになる

## 動作フロー
```
ISSUE Open  → Start date = 今日, Target date = 今日+14日（仮バー表示）
ISSUE Close → Target date = 今日（確定、バー長さが確定）
```

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)