### PR TITLE
fix: claude-pr-review workflow - restrict tools & fix review comment posting

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -29,11 +29,21 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_tools: "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(git diff:*),Bash(git log:*)"
           prompt: |
-            このPRを日本語でレビューしてください。以下の観点でコメントしてください：
-            - バグ・ロジックの誤り
-            - セキュリティリスク（機密情報の露出、インジェクション等）
-            - 設計上の問題点
-            - 改善提案（必要な場合のみ）
+            リポジトリ: ${{ github.repository }}
+            PR番号: ${{ github.event.pull_request.number }}
 
-            軽微なスタイルの指摘は省略し、重要な問題に絞ってください。
+            上記のPRを以下の手順でレビューしてください：
+
+            1. `gh pr diff ${{ github.event.pull_request.number }}` で差分を確認する
+            2. 以下の観点でレビューコメントを作成する：
+               - バグ・ロジックの誤り
+               - セキュリティリスク（機密情報の露出、インジェクション等）
+               - 設計上の問題点
+               - 改善提案（必要な場合のみ）
+            3. `gh pr comment ${{ github.event.pull_request.number }} --body "レビュー内容"` でコメントを投稿する
+
+            軽微なスタイルの指摘は省略し、重要な問題に絞って日本語でコメントしてください。
+            プロジェクトのスクリプトや分析ツールは実行しないでください。


### PR DESCRIPTION
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> クロードが迷路に迷い込む、許可されぬツール実行の罪。
> analytics エンジンを走らせてレビューを忘れた過去、
> allowed_tools で牢を造り、gh と git だけを解き放つ。
> token と prompt の光でコンテキストを灯し、
> 自動レビューの声を再びこの世に呼び戻す。

---
<!-- summary-bot-end -->

## 問題

PR #64 マージ後、Claudeが自動レビューコメントを投稿しなかった。

## 原因

`claude-code-action` が `allowed_tools` 未指定のため、Claudeがプロジェクトの
スクリプト（`python3 .claude/analytics/engine.py`）を実行してしまっていた。

## 修正内容

- `allowed_tools` を `gh pr view/diff/comment` と `git diff/log` のみに制限
- `github_token` を明示的に渡すよう追加
- プロンプトにPRコンテキスト（repo, PR番号）と投稿手順を明示
- プロジェクトスクリプトを実行しないよう指示を追加

## 動作確認

このPRマージ後、次のPRで自動レビューが投稿されることを確認する。

Closes #62