### PR TITLE
feat: switch PR review to qodo-ai/pr-agent with Claude model

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -21,5 +21,6 @@ jobs:
           ANTHROPIC.KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           config.model: "anthropic/claude-sonnet-4-6"
           config.fallback_models: '["anthropic/claude-haiku-4-5-20251001"]'
+          config.language: "ja"
           pr_reviewer.extra_instructions: "日本語でコメントしてください。軽微なスタイル指摘は省略し、バグ・セキュリティリスク・設計上の問題に絞ってください。"
           pr_description.extra_instructions: "日本語でPRの説明を生成してください。"


### PR DESCRIPTION
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> Claude-sonnetが舞台に立ち、
> agentの暴走を鎮める物語。
> CLAUDE.mdの罠から逃れ、
> qodo-ai/pr-agentの専用設計で、
> 日本語レビューの光を纏いながら、
> バグとセキュリティの闇を照らす。

---
<!-- summary-bot-end -->

## Summary

- `anthropics/claude-code-action`（agentモード）から `qodo-ai/pr-agent` に切り替え
- Anthropic `claude-sonnet-4-6` モデルを使用（litellm経由）
- フォールバック: `claude-haiku-4-5-20251001`
- 日本語レビュー、バグ・セキュリティ・設計問題に絞った指示

## 切り替え理由

`claude-code-action` はagentモードでCLAUDE.mdを読み込み、プロジェクト独自スクリプトを実行してしまうため、PRレビュー専用設計の `qodo-ai/pr-agent` に変更。

## 動作

| トリガー | 動作 |
|---|---|
| PR open/sync/reopen | 自動で `/describe` + `/review` 実行 |
| PRコメントで `/review` | 手動レビュー |
| PRコメントで `/improve` | コード改善提案 |
| PRコメントで `/ask <質問>` | 質問応答 |

Closes #61