### PR TITLE
fix: AppleScriptモーダルのエスケープ処理・プロンプト表示を改善

### DIFF
--- a/src/hooks/user-prompt-submit.py
+++ b/src/hooks/user-prompt-submit.py
@@ -381,11 +381,18 @@ def main():
                 reason = detection.get("reason", "")
                 judgment_failed = detection.get("judgment_failed", False)
 
+                # プロンプトの冒頭をモーダルに表示（どの発言が引っかかったか識別用）
+                prompt_preview = user_prompt[:40].replace('\n', ' ')
+                if len(user_prompt) > 40:
+                    prompt_preview += "..."
+                prompt_line = f"▶ 「{prompt_preview}」"
+
                 # デフォルト値を先に設定（NameError防止 + 明示的な初期化）
                 alert_title = "🔴 話題逸脱の可能性"
                 alert_message = (
                     "現在のセッションのトピックと関連が薄いかもしれません。\n"
-                    "別トピックの場合は新しいセッションの開始を検討してください。"
+                    "別トピックの場合は新しいセッションの開始を検討してください。\n"
+                    f"{prompt_line}"
                 )
 
                 if judgment_failed:
@@ -397,7 +404,8 @@ def main():
                     alert_message = (
                         "LLMが判定できませんでした。\n"
                         "話題が逸脱している可能性があります。\n"
-                        "念のため確認してください。"
+                        "念のため確認してください。\n"
+                        f"{prompt_line}"
                     )
                 else:
                     additional_parts.append(


### PR DESCRIPTION
### **User description**
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> AppleScript の文字列に潜む危険を退治し、
> `"` と `\` の二つの鬼をエスケープで縛る。
> `\n` は改行の本当の姿へ、NameError の罠も初期化で埋める。
> そして冒頭40文字をモーダルに刻み込み、
> 並走する複数セッションの中から、
> どの声が呼び鈴を鳴らしたかが一目で映る。

---
<!-- summary-bot-end -->

## Summary

PR #72 のレビュー指摘対応 + モーダルの識別性向上

### 変更内容

**1. AppleScriptエスケープ処理とNameError防止**
- `alert_title`/`alert_message` を if-else の前に初期化（NameError防止）
- `\\n`（リテラル）を `\n`（実改行）に修正
- `_as_str()` ヘルパーで AppleScript 文字列を安全に構築
  - `"` と `\` を自動エスケープ
  - `\n` を AppleScript の `& return &` に変換

**2. モーダルにプロンプト冒頭を表示**
- `alert_message` 末尾に `▶ 「プロンプト冒頭40文字...」` を追加
- 複数セッション並走時にどの発言がトリガーかを一目で識別可能に

```
⚠️ 話題逸脱：判定不能

LLMが判定できませんでした。
話題が逸脱している可能性があります。
念のため確認してください。
▶ 「これは今私がこの会話したから出し...」
```

Closes #70


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- AppleScriptエスケープ処理を改善し安全な文字列変換を実装

- NameError防止のため変数初期化をif-else前に移動

- リテラル改行（\\n）を実改行（\n）に修正

- モーダルにプロンプト冒頭40文字を表示し発言の識別性向上


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["判定失敗フラグ判定"] --> B{"judgment_failed?"}
  B -->|True| C["⚠️ 判定不能メッセージ"]
  B -->|False| D["🔴 逸脱検知メッセージ"]
  C --> E["_as_str関数でエスケープ"]
  D --> E
  E --> F["プロンプト冒頭40文字追加"]
  F --> G["AppleScriptモーダル表示"]
  G --> H["クリックまで表示"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>user-prompt-submit.py</strong><dd><code>AppleScriptエスケープ処理とプロンプト表示を改善</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/hooks/user-prompt-submit.py

<ul><li><code>_as_str()</code>ヘルパー関数を追加し、AppleScript文字列のダブルクォート・バックスラッシュを安全にエスケープ<br> <li> <code>\n</code>をAppleScriptの<code>& return &</code>に変換して実改行を実現<br> <li> <code>alert_title</code>と<code>alert_message</code>をif-else前に初期化してNameError防止<br> <li> <code>alert_message</code>末尾にプロンプト冒頭40文字を<code>▶ 「...」</code>形式で追加し複数セッション並走時の識別性向上<br> <li> リテラル改行<code>\\n</code>を実改行<code>\n</code>に修正</ul>


</details>


  </td>
  <td><a href="https://github.com/miyashita337/claude-context-manager/pull/74/files#diff-dc630934fddb02b009b1408725135f6e54053b75d923dff757254956ae062b96">+32/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

