### PR TITLE
fix: hookコマンドを $CLAUDE_PROJECT_DIR に変更（worktree/tmux混在対応）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/src/hooks/user-prompt-submit.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/src/hooks/user-prompt-submit.py\"",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/src/hooks/post-tool-use.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/src/hooks/post-tool-use.py\"",
             "timeout": 30
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/src/hooks/stop.py\"",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/src/hooks/stop.py\"",
             "timeout": 10
           }
         ]

--- a/tests/test_hook_validation.py
+++ b/tests/test_hook_validation.py
@@ -8,6 +8,7 @@ and correctly configured.
 """
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -228,6 +229,242 @@ class TestHookScriptFiles:
             f"Shared module not found: {module_path}\n"
             "Hook scripts depend on shared modules for logging functionality."
         )
+
+
+class TestHookPathResolution:
+    """Verify that hook commands use CWD-independent path resolution.
+
+    Bug: Using $(git rev-parse --show-toplevel) is CWD-dependent and breaks when:
+    1. Running from a git worktree (resolves to worktree root, not main repo)
+    2. tmux session with CWD in another git repo (resolves to wrong repo entirely)
+
+    Fix: Use $CLAUDE_PROJECT_DIR, an officially documented Claude Code env var
+    that always points to the project root regardless of CWD.
+    """
+
+    @pytest.mark.parametrize("event_type", REQUIRED_HOOK_EVENTS)
+    def test_command_uses_claude_project_dir(self, hooks_config, event_type):
+        """Hook commands must use $CLAUDE_PROJECT_DIR for path resolution."""
+        hooks = hooks_config.get("hooks", {})
+        if event_type not in hooks:
+            pytest.skip(f"{event_type} not present")
+
+        expected_script = EXPECTED_HOOK_FILES[event_type]
+        event_hooks = hooks[event_type]
+
+        for group in event_hooks:
+            for hook in group.get("hooks", []):
+                if hook.get("type") != "command":
+                    continue
+                command = hook.get("command", "")
+                if expected_script in command:
+                    assert "$CLAUDE_PROJECT_DIR" in command, (
+                        f"Hook command for '{event_type}' must use $CLAUDE_PROJECT_DIR "
+                        f"for CWD-independent path resolution. Got: {command}"
+                    )
+
+    @pytest.mark.parametrize("event_type", REQUIRED_HOOK_EVENTS)
+    def test_command_does_not_use_git_rev_parse(self, hooks_config, event_type):
+        """Hook commands must NOT use git rev-parse (CWD-dependent)."""
+        hooks = hooks_config.get("hooks", {})
+        if event_type not in hooks:
+            pytest.skip(f"{event_type} not present")
+
+        expected_script = EXPECTED_HOOK_FILES[event_type]
+        event_hooks = hooks[event_type]
+
+        for group in event_hooks:
+            for hook in group.get("hooks", []):
+                if hook.get("type") != "command":
+                    continue
+                command = hook.get("command", "")
+                if expected_script in command:
+                    assert "git rev-parse" not in command, (
+                        f"Hook command for '{event_type}' must NOT use "
+                        f"'git rev-parse --show-toplevel' as it is CWD-dependent "
+                        f"and breaks in worktrees and tmux sessions. "
+                        f"Use $CLAUDE_PROJECT_DIR instead. Got: {command}"
+                    )
+
+
+class TestHookPathBoundary:
+    """Boundary-value tests: verify git rev-parse --show-toplevel is CWD-dependent.
+
+    These tests document WHY the old approach was broken, by proving that
+    git rev-parse --show-toplevel returns different values depending on CWD.
+    """
+
+    MAIN_REPO_ROOT = PROJECT_ROOT
+
+    def _find_worktree(self):
+        """Find an existing worktree path, or return None."""
+        worktrees_dir = self.MAIN_REPO_ROOT / ".claude" / "worktrees"
+        if not worktrees_dir.exists():
+            return None
+        for child in worktrees_dir.iterdir():
+            if child.is_dir() and (child / ".git").exists():
+                return child
+        return None
+
+    def test_hook_path_repo_root_returns_correct_toplevel(self):
+        """From main repo root, show-toplevel returns the repo root."""
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(self.MAIN_REPO_ROOT),
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        toplevel = Path(result.stdout.strip())
+        assert toplevel == self.MAIN_REPO_ROOT.resolve(), (
+            f"Expected {self.MAIN_REPO_ROOT.resolve()}, got {toplevel}"
+        )
+
+    def test_hook_path_deep_subdir_returns_correct_toplevel(self):
+        """From a deeply nested subdir, show-toplevel still returns repo root."""
+        deep_dir = self.MAIN_REPO_ROOT / "src" / "hooks" / "shared"
+        if not deep_dir.exists():
+            pytest.skip(f"Deep subdir not found: {deep_dir}")
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(deep_dir),
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        toplevel = Path(result.stdout.strip())
+        assert toplevel == self.MAIN_REPO_ROOT.resolve(), (
+            f"Expected {self.MAIN_REPO_ROOT.resolve()}, got {toplevel}"
+        )
+
+    def test_hook_path_worktree_returns_wrong_toplevel(self):
+        """From a worktree, show-toplevel returns the WORKTREE root, not main repo.
+
+        This documents the bug that $CLAUDE_PROJECT_DIR fixes.
+        """
+        worktree_path = self._find_worktree()
+        if worktree_path is None:
+            pytest.skip("No worktree found to test with")
+
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(worktree_path),
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0
+        toplevel = Path(result.stdout.strip())
+        # The bug: worktree returns its own root, not the main repo root
+        assert toplevel != self.MAIN_REPO_ROOT.resolve(), (
+            f"show-toplevel from worktree should NOT equal main repo root, "
+            f"but got {toplevel}. This test documents the CWD-dependency bug."
+        )
+
+    def test_hook_path_outside_git_returns_error(self):
+        """From outside any git repo, show-toplevel fails with exit code 128."""
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd="/tmp",
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0, (
+            "git rev-parse --show-toplevel should fail outside a git repo"
+        )
+        assert "not a git repository" in result.stderr, (
+            f"Expected 'not a git repository' error, got: {result.stderr}"
+        )
+
+
+class TestHookPathSuccess:
+    """Success tests: verify the fixed hook commands resolve to valid paths.
+
+    With $CLAUDE_PROJECT_DIR set to the project root, every hook command
+    must resolve to an existing Python script.
+    """
+
+    @pytest.mark.parametrize("event_type", REQUIRED_HOOK_EVENTS)
+    def test_hook_path_resolved_command_points_to_existing_script(
+        self, hooks_config, event_type,
+    ):
+        """When $CLAUDE_PROJECT_DIR = PROJECT_ROOT, hook script path must exist."""
+        hooks = hooks_config.get("hooks", {})
+        if event_type not in hooks:
+            pytest.skip(f"{event_type} not present")
+
+        expected_script = EXPECTED_HOOK_FILES[event_type]
+        event_hooks = hooks[event_type]
+
+        for group in event_hooks:
+            for hook in group.get("hooks", []):
+                if hook.get("type") != "command":
+                    continue
+                command = hook.get("command", "")
+                if expected_script not in command:
+                    continue
+                # Simulate $CLAUDE_PROJECT_DIR expansion
+                resolved = command.replace(
+                    "$CLAUDE_PROJECT_DIR", str(PROJECT_ROOT),
+                )
+                # Extract the script path (between quotes after python3)
+                # Format: python3 "<path>"
+                parts = resolved.split('"')
+                assert len(parts) >= 2, (
+                    f"Cannot parse script path from command: {resolved}"
+                )
+                script_path = Path(parts[1])
+                assert script_path.exists(), (
+                    f"Resolved hook script does not exist: {script_path}\n"
+                    f"Command: {command}\n"
+                    f"$CLAUDE_PROJECT_DIR would be: {PROJECT_ROOT}"
+                )
+
+    @pytest.mark.parametrize("event_type", REQUIRED_HOOK_EVENTS)
+    def test_hook_path_command_format_is_correct(self, hooks_config, event_type):
+        """Hook command must follow: python3 "$CLAUDE_PROJECT_DIR/src/hooks/<script>.py" """
+        hooks = hooks_config.get("hooks", {})
+        if event_type not in hooks:
+            pytest.skip(f"{event_type} not present")
+
+        expected_script = EXPECTED_HOOK_FILES[event_type]
+        expected_command = (
+            f'python3 "$CLAUDE_PROJECT_DIR/src/hooks/{expected_script}"'
+        )
+        event_hooks = hooks[event_type]
+
+        found = False
+        for group in event_hooks:
+            for hook in group.get("hooks", []):
+                if hook.get("type") != "command":
+                    continue
+                command = hook.get("command", "")
+                if expected_script in command:
+                    found = True
+                    assert command == expected_command, (
+                        f"Hook command format mismatch for '{event_type}'.\n"
+                        f"Expected: {expected_command}\n"
+                        f"Got:      {command}"
+                    )
+        assert found, f"No command found for {event_type}"
+
+    def test_hook_path_worktree_also_has_hook_scripts(self):
+        """In worktrees, hook scripts should also exist (git-tracked files)."""
+        worktrees_dir = PROJECT_ROOT / ".claude" / "worktrees"
+        if not worktrees_dir.exists():
+            pytest.skip("No worktrees directory found")
+
+        worktree_path = None
+        for child in worktrees_dir.iterdir():
+            if child.is_dir() and (child / ".git").exists():
+                worktree_path = child
+                break
+
+        if worktree_path is None:
+            pytest.skip("No worktree found to test with")
+
+        for script_name in EXPECTED_HOOK_FILES.values():
+            script_path = worktree_path / "src" / "hooks" / script_name
+            assert script_path.exists(), (
+                f"Hook script missing in worktree: {script_path}\n"
+                "Git-tracked files should be present in worktrees."
+            )
 
 
 class TestHookTimeouts:


### PR DESCRIPTION
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> 暗き迷路で二つの道が交わり、
> iCloudの奥底からtmuxウィンドウが迷い込む。
> gitの頂上を指さす古き指標が、
> 異なるCWDで別の世界を映す——
> $CLAUDE_PROJECT_DIRの光で、
> どのworktreeからも同じ道を歩む。

---
<!-- summary-bot-end -->

## Summary

`.claude/settings.json` の全hookコマンドが `$(git rev-parse --show-toplevel)` でパス解決していた。
このコマンド自体は通常動作するが、**hookが意図しないCWDで実行される**ケースで壊れる。

## バグの本質

`git rev-parse --show-toplevel` は壊れていない。問題は **hookの実行CWD** が Claude セッションのCWDと異なる場合がある点。

### 実際に起きた再現シナリオ

```
# Step 1: iCloud vault から --tmux で起動
cd ~/Library/Mobile Documents/.../my-vault
claude -w icloud_nofreespace --tmux
# → tmux session名: git-repos_worktree-icloud_nofreespace
# → my-vault に .claude/settings.json なし → hookなし → 正常 ✅

# Step 2: claude-context-manager から --tmux で起動
cd ~/claude-context-manager
claude -w test --tmux
# → 同名のtmuxセッションに「新しいウィンドウ」として混入
# → そのウィンドウのシェルCWD = my-vault（iCloudパス）
# → hookが発火、CWD=my-vault で git rev-parse --show-toplevel を実行
# → /Users/.../my-vault が返る
# → /Users/.../my-vault/src/hooks/user-prompt-submit.py → 存在しない → ブロック ❌
```

**実際のエラー:**
```
UserPromptSubmit operation blocked by hook:
python3: can't open file '/Users/.../iCloud~md~obsidian/Documents/my-vault/src/hooks/user-prompt-submit.py': [Errno 2] No such file or directory
```

### なぜ iCloud vault の worktree が ~/git-repos/ 以下になるのか

`my-vault` に `.claude/settings.json` がないため、Claude は git の common dir（`~/git-repos/my-vault-git`）を基準に worktree を作成する。結果として `~/git-repos/.claude/worktrees/icloud_nofreespace` になり、tmux session 名の生成基準も `git-repos` になる。これが session 名衝突の根本原因。

## 修正

`$CLAUDE_PROJECT_DIR`（Claude Code が hook 実行時に強制セットする公式環境変数）を使用。CWD が何であっても正しいプロジェクトrootを指すため、tmux 混在問題を回避できる。

```diff
- python3 "$(git rev-parse --show-toplevel)/src/hooks/user-prompt-submit.py"
+ python3 "$CLAUDE_PROJECT_DIR/src/hooks/user-prompt-submit.py"
```

対象: UserPromptSubmit / PostToolUse / Stop（3箇所）

## テスト

| クラス | テスト数 | 内容 |
|--------|---------|------|
| TestHookPathResolution | 6 | $CLAUDE_PROJECT_DIR使用確認 / git rev-parse排除確認 |
| TestHookPathBoundary | 4 | repo root / deep subdir / worktree / git外 |
| TestHookPathSuccess | 7 | スクリプト実在確認 / コマンド形式確認 / worktree内存在確認 |

**結果: 48/48 passed, 0 failed**（既存31 + 新規17）

## Test plan

- [x] `make test-python` → 48/48 passed
- [x] pre-commit checks passed（secrets / unwanted files）
- [x] 既存31テスト全回帰なし

Closes #85