### PR TITLE
feat: セッションタイトル管理（iTerm2タブ + ステータスライン）

### DIFF
--- a/.claude/skills/title/SKILL.md
+++ b/.claude/skills/title/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: title
+description: Generate or update session title for iTerm2 tab and status line
+tools: Bash
+model: haiku
+---
+
+# /title - Session Title Management
+
+## Usage
+- `/title` — AI generates a title from conversation context
+- `/title My Custom Title` — Set a specific title manually
+
+## Behavior
+
+1. If an argument is provided, use it as the title directly (source: `manual`)
+2. If no argument, generate a concise title (English, max 6 words) from conversation context (source: `manual`)
+3. Update the title file and iTerm2 tab:
+
+```bash
+TITLE="YOUR_TITLE_HERE"
+SESSION_ID="$CLAUDE_SESSION_ID"
+printf '\033]1;%s\007' "$TITLE" > /dev/tty 2>/dev/null
+mkdir -p ~/.claude/session-titles
+printf '%s\nmanual\n' "$TITLE" > ~/.claude/session-titles/${SESSION_ID}.txt
+```
+
+4. Confirm the title was set
+
+## Rules
+- Title must be concise: max 6 words, English
+- Always set source as `manual` (this is a user-initiated override)
+- Do not ask for confirmation — just set the title
+- If `CLAUDE_SESSION_ID` is not available, read session_id from the most recent title file or skip title file update

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,15 +26,15 @@ jobs:
         pip install ruff black isort
 
     - name: Run ruff
-      run: ruff check src/hooks/
+      run: ruff check src/hooks/ src/session-title/
       continue-on-error: true
 
     - name: Check formatting with black
-      run: black --check src/hooks/
+      run: black --check src/hooks/ src/session-title/
       continue-on-error: true
 
     - name: Check import sorting with isort
-      run: isort --check-only src/hooks/
+      run: isort --check-only src/hooks/ src/session-title/
       continue-on-error: true
 
   typescript-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Run Python tests
       run: |
-        pytest tests/ -v --cov=src/hooks --cov-report=xml --cov-report=term
+        pytest tests/ -v --cov=src/hooks --cov=src/session-title --cov-report=xml --cov-report=term
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Claude Context Manager - Makefile
 # 便利なショートカットコマンド集
 
-.PHONY: help install test test-python test-ts test-all test-watch clean build dev lint format format-check startup-check pre-git-check git-clean git-safe-push git-hooks validate-hooks test-hooks fix-hooks backup-hooks restore-hooks ci-watch ci-auto-fix ccusage-report analytics analytics-update validate-analytics review review-latest review-list update-antipatterns install-topic-server start-topic-server stop-topic-server uninstall-topic-server status-topic-server sync-labels
+.PHONY: help install test test-python test-ts test-all test-watch clean build dev lint format format-check startup-check pre-git-check git-clean git-safe-push git-hooks validate-hooks test-hooks fix-hooks backup-hooks restore-hooks ci-watch ci-auto-fix ccusage-report analytics analytics-update validate-analytics review review-latest review-list update-antipatterns install-topic-server start-topic-server stop-topic-server uninstall-topic-server status-topic-server sync-labels install-session-title uninstall-session-title
 
 # デフォルトターゲット: ヘルプを表示
 help:
@@ -33,6 +33,10 @@ help:
 	@echo "  make review-latest        - 最新セッションをキャッシュ"
 	@echo "  make review-list          - 既存レビュー一覧表示"
 	@echo "  make update-antipatterns  - /antipatterns スキルの更新チェック"
+	@echo ""
+	@echo "🏷️  セッションタイトル (Issue #109):"
+	@echo "  make install-session-title   - セッションタイトルhookをインストール"
+	@echo "  make uninstall-session-title - セッションタイトルhookをアンインストール"
 	@echo ""
 	@echo "🧠 話題逸脱検出サーバー (Issue #28):"
 	@echo "  make install-topic-server   - sentence-transformers インストール + launchd 登録"
@@ -313,6 +317,26 @@ update-antipatterns:
 	@echo "  /fact-check \"Verify antipatterns match official docs at code.claude.com/docs/en/best-practices\""
 	@echo ""
 	@echo "💡 30日以上経過している場合は更新を推奨します"
+
+# ============================================================
+# セッションタイトル管理 (Issue #109)
+# ============================================================
+
+install-session-title:
+	@echo "🏷️  セッションタイトルhookをインストール中..."
+	@chmod +x src/session-title/install.sh
+	@src/session-title/install.sh
+
+uninstall-session-title:
+	@echo "🏷️  セッションタイトルhookをアンインストール中..."
+	@rm -f ~/.claude/scripts/session_title_utils.py
+	@rm -f ~/.claude/scripts/session-start-title.py
+	@rm -f ~/.claude/scripts/prompt-title-check.py
+	@rm -f ~/.claude/scripts/statusline.py
+	@rm -rf ~/.claude/skills/title
+	@rm -rf ~/.claude/session-titles
+	@echo "✅ アンインストール完了"
+	@echo "Note: ~/.claude/settings.json の SessionStart/UserPromptSubmit/StatusLine エントリは手動で削除してください"
 
 # ============================================================
 # 話題逸脱検出サーバー管理 (Issue #28)

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "test:python": "python3 -m pytest tests/ -v --cov=src/hooks",
     "test:all": "npm run test:python && npm test",
     "test:ci": "npm run test:python -- --cov-report=xml && npm test -- --coverage",
-    "lint:python": "python3 -m flake8 src/hooks --count --select=E9,F63,F7,F82 --show-source --statistics",
-    "format:python": "python3 -m black src/hooks tests",
-    "format:check": "python3 -m black --check src/hooks tests",
+    "lint:python": "python3 -m flake8 src/hooks src/session-title --count --select=E9,F63,F7,F82 --show-source --statistics",
+    "format:python": "python3 -m black src/hooks src/session-title tests",
+    "format:check": "python3 -m black --check src/hooks src/session-title tests",
     "status": "tsx src/cli/index.ts status",
     "search": "tsx src/cli/index.ts search"
   },

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,6 @@ addopts =
     -v
     --tb=short
     --cov=src/hooks
+    --cov=src/session-title
     --cov-report=term-missing
     --cov-report=html

--- a/src/session-title/install.sh
+++ b/src/session-title/install.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Session Title インストーラー (Issue #109)
+# セッションタイトル管理スクリプトを ~/.claude/ にデプロイする
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEST_SCRIPTS="$HOME/.claude/scripts"
+DEST_SKILL="$HOME/.claude/skills/title"
+DEST_TITLES="$HOME/.claude/session-titles"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+echo "🏷️  Session Title インストール開始..."
+echo "   Source:  $SCRIPT_DIR"
+echo "   Dest:    $DEST_SCRIPTS"
+echo ""
+
+# --- 1. スクリプトコピー ---
+echo "📦 スクリプトをコピー中..."
+mkdir -p "$DEST_SCRIPTS"
+cp "$SCRIPT_DIR/session_title_utils.py" "$DEST_SCRIPTS/"
+cp "$SCRIPT_DIR/session-start-title.py" "$DEST_SCRIPTS/"
+cp "$SCRIPT_DIR/prompt-title-check.py" "$DEST_SCRIPTS/"
+cp "$SCRIPT_DIR/statusline.py" "$DEST_SCRIPTS/"
+echo "   ✅ 4ファイルをコピー完了"
+
+# --- 2. SKILL.md コピー ---
+echo "📋 SKILL.md をコピー中..."
+mkdir -p "$DEST_SKILL"
+REPO_SKILL_DIR="$SCRIPT_DIR/../../.claude/skills/title"
+if [ -f "$REPO_SKILL_DIR/SKILL.md" ]; then
+    cp "$REPO_SKILL_DIR/SKILL.md" "$DEST_SKILL/"
+    echo "   ✅ SKILL.md コピー完了"
+else
+    echo "   ⚠️  SKILL.md が見つかりません: $REPO_SKILL_DIR"
+fi
+
+# --- 3. タイトル保存ディレクトリ作成 ---
+mkdir -p "$DEST_TITLES"
+echo "   ✅ session-titles ディレクトリ作成完了"
+
+# --- 4. settings.json にフック設定をマージ ---
+echo "🔧 settings.json にフック設定をマージ中..."
+python3 - "$SETTINGS_FILE" "$DEST_SCRIPTS" << 'PYEOF'
+import json
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+scripts_dir = sys.argv[2]
+
+# Load existing settings
+if settings_path.exists():
+    settings = json.loads(settings_path.read_text())
+else:
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+
+# Helper: add hook entry if not already present
+def ensure_hook(event_name, hook_entry):
+    event_hooks = hooks.setdefault(event_name, [])
+    # Check if already registered (by command match)
+    for existing in event_hooks:
+        if existing.get("command") == hook_entry["command"]:
+            return  # Already present
+    event_hooks.append(hook_entry)
+
+# SessionStart hook
+ensure_hook("SessionStart", {
+    "type": "command",
+    "command": f"python3 {scripts_dir}/session-start-title.py"
+})
+
+# UserPromptSubmit hook
+ensure_hook("UserPromptSubmit", {
+    "type": "command",
+    "command": f"python3 {scripts_dir}/prompt-title-check.py"
+})
+
+# StatusLine hook
+ensure_hook("StatusLine", {
+    "type": "command",
+    "command": f"python3 {scripts_dir}/statusline.py"
+})
+
+# Write back
+settings_path.write_text(json.dumps(settings, indent=2, ensure_ascii=False) + "\n")
+PYEOF
+
+echo "   ✅ フック設定マージ完了"
+
+echo ""
+echo "✅ インストール完了！"
+echo ""
+echo "管理コマンド:"
+echo "  make install-session-title    - 再インストール"
+echo "  make uninstall-session-title  - アンインストール"

--- a/src/session-title/prompt-title-check.py
+++ b/src/session-title/prompt-title-check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: Inject AI title generation after 2+ user messages."""
+
+import json
+import sys
+
+# Allow importing sibling module
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent))
+from session_title_utils import read_title
+
+
+def count_user_messages(transcript_path: str) -> int:
+    """Count user messages in transcript JSONL file."""
+    count = 0
+    try:
+        with open(transcript_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    if entry.get("type") == "human":
+                        count += 1
+                except json.JSONDecodeError:
+                    continue
+    except (FileNotFoundError, PermissionError):
+        pass
+    return count
+
+
+def main():
+    data = json.load(sys.stdin)
+    session_id = data.get("session_id", "")
+    transcript_path = data.get("transcript_path", "")
+
+    if not session_id:
+        return
+
+    # Fast path: already has AI or manual title
+    _, source = read_title(session_id)
+    if source in ("ai", "manual"):
+        return
+
+    # Check user message count
+    if not transcript_path:
+        return
+
+    user_msg_count = count_user_messages(transcript_path)
+    if user_msg_count < 2:
+        return
+
+    # Inject title generation instruction
+    instruction = (
+        f"[Session Title Request] This session still has a branch-based title. "
+        f"Based on the conversation so far, generate a concise session title "
+        f"(English, max 6 words) that captures the main topic. Then run this command:\n"
+        f"printf '\\033]1;%s\\007' \"YOUR_TITLE\" > /dev/tty 2>/dev/null && "
+        f"mkdir -p ~/.claude/session-titles && "
+        f"printf '%s\\nai\\n' \"YOUR_TITLE\" > ~/.claude/session-titles/{session_id}.txt\n"
+        f"Replace YOUR_TITLE with the generated title. No confirmation needed. "
+        f"After setting the title, respond to the user's message normally."
+    )
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": instruction,
+        }
+    }
+    json.dump(output, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/session-title/session-start-title.py
+++ b/src/session-title/session-start-title.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""SessionStart hook: Set initial session title from branch name."""
+
+import json
+import sys
+
+# Allow importing sibling module
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent))
+from session_title_utils import get_branch_name, read_title, set_iterm2_tab, write_title
+
+
+def main():
+    data = json.load(sys.stdin)
+    session_id = data.get("session_id", "")
+    cwd = data.get("cwd", "")
+
+    if not session_id:
+        return
+
+    # Check for existing title (resume case)
+    title, source = read_title(session_id)
+    if title:
+        set_iterm2_tab(title)
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": (
+                    f"[Session Title: {title} (source: {source}) "
+                    f"| Session ID: {session_id}]"
+                ),
+            }
+        }
+        json.dump(output, sys.stdout)
+        return
+
+    # New session: use branch name as initial title
+    branch = get_branch_name(cwd)
+    title = branch if branch else __import__("os").path.basename(cwd)
+
+    write_title(session_id, title, "branch")
+    set_iterm2_tab(title)
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": (
+                f"[Session Title: {title} (source: branch) "
+                f"| Session ID: {session_id}]"
+            ),
+        }
+    }
+    json.dump(output, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/session-title/session_title_utils.py
+++ b/src/session-title/session_title_utils.py
@@ -1,0 +1,51 @@
+"""Shared utilities for session title management."""
+
+import os
+import subprocess
+from pathlib import Path
+
+TITLES_DIR = Path.home() / ".claude" / "session-titles"
+
+
+def read_title(session_id: str) -> tuple[str | None, str | None]:
+    """Read title and source from title file. Returns (title, source) or (None, None)."""
+    path = TITLES_DIR / f"{session_id}.txt"
+    try:
+        lines = path.read_text().splitlines()
+        title = lines[0] if len(lines) > 0 else None
+        source = lines[1] if len(lines) > 1 else None
+        return title, source
+    except (FileNotFoundError, IndexError):
+        return None, None
+
+
+def write_title(session_id: str, title: str, source: str) -> None:
+    """Write title and source to title file."""
+    TITLES_DIR.mkdir(parents=True, exist_ok=True)
+    path = TITLES_DIR / f"{session_id}.txt"
+    path.write_text(f"{title}\n{source}\n")
+
+
+def set_iterm2_tab(title: str) -> None:
+    """Set iTerm2 tab title via /dev/tty to bypass stdout capture."""
+    try:
+        with open("/dev/tty", "w") as tty:
+            tty.write(f"\033]1;{title}\007")
+    except OSError:
+        pass
+
+
+def get_branch_name(cwd: str | None = None) -> str | None:
+    """Get current git branch name."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            cwd=cwd,
+        )
+        branch = result.stdout.strip()
+        return branch if branch else None
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None

--- a/src/session-title/statusline.py
+++ b/src/session-title/statusline.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""StatusLine script: Display session title in Claude Code status bar."""
+
+import json
+import os
+import sys
+
+# Allow importing sibling module
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent))
+from session_title_utils import get_branch_name, read_title, set_iterm2_tab
+
+
+def main():
+    data = json.load(sys.stdin)
+    session_id = data.get("session_id", "")
+    cwd = data.get("cwd", "")
+    model = data.get("model", {})
+    model_name = model.get("display_name", "?") if isinstance(model, dict) else "?"
+    ctx = data.get("context_window", {})
+    used_pct = ctx.get("used_percentage")
+    pct_str = f"{used_pct}%" if used_pct is not None else "..."
+
+    # Read title
+    title = None
+    if session_id:
+        title, _ = read_title(session_id)
+
+    # Fallback: branch name or directory name
+    if not title:
+        title = get_branch_name(cwd) or os.path.basename(cwd or "")
+
+    # Refresh iTerm2 tab title on every statusline update (ensures persistence)
+    if title:
+        set_iterm2_tab(title)
+
+    # Output status line
+    print(f"[{title}] | {model_name} | {pct_str} ctx")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Tests for session title management system (Issue #109).
+
+Test strategy:
+  - importlib.util for hyphenated filenames (same pattern as test_user_prompt_submit.py)
+  - monkeypatch TITLES_DIR to tmp_path for isolation
+  - unittest.mock.patch for /dev/tty, subprocess.run
+"""
+
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── module loaders ───────────────────────────────────────────────────────────
+SESSION_TITLE_DIR = Path(__file__).parent.parent / "src" / "session-title"
+
+
+def _load_utils():
+    spec = importlib.util.spec_from_file_location(
+        "session_title_utils",
+        SESSION_TITLE_DIR / "session_title_utils.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_session_start():
+    spec = importlib.util.spec_from_file_location(
+        "session_start_title",
+        SESSION_TITLE_DIR / "session-start-title.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_prompt_check():
+    spec = importlib.util.spec_from_file_location(
+        "prompt_title_check",
+        SESSION_TITLE_DIR / "prompt-title-check.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_statusline():
+    spec = importlib.util.spec_from_file_location(
+        "statusline",
+        SESSION_TITLE_DIR / "statusline.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+utils = _load_utils()
+
+
+# =============================================================================
+# A. session_title_utils.py (4 tests)
+# =============================================================================
+
+
+class TestSessionTitleUtils:
+    """Tests for shared utility functions."""
+
+    def test_write_and_read_title(self, tmp_path, monkeypatch):
+        """Write title then read it back — title and source must match."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        utils.write_title("sess-001", "Fix Auth Bug", "branch")
+        title, source = utils.read_title("sess-001")
+        assert title == "Fix Auth Bug"
+        assert source == "branch"
+
+    def test_read_title_missing_file(self, tmp_path, monkeypatch):
+        """Non-existent session file returns (None, None)."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        title, source = utils.read_title("nonexistent")
+        assert title is None
+        assert source is None
+
+    def test_set_iterm2_tab_no_tty(self):
+        """OSError on /dev/tty open is silently caught."""
+        with patch("builtins.open", side_effect=OSError("no tty")):
+            # Should not raise
+            utils.set_iterm2_tab("test title")
+
+    def test_get_branch_name(self):
+        """Mocked subprocess returns branch name."""
+        mock_result = MagicMock()
+        mock_result.stdout = "feature/session-title\n"
+        with patch("subprocess.run", return_value=mock_result):
+            branch = utils.get_branch_name("/some/dir")
+        assert branch == "feature/session-title"
+
+
+# =============================================================================
+# B. session-start-title.py (3 tests)
+# =============================================================================
+
+
+class TestSessionStartTitle:
+    """Tests for SessionStart hook."""
+
+    def test_new_session_sets_branch_title(self, tmp_path, monkeypatch):
+        """New session with no existing title sets branch name as title."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+
+        start_mod = _load_session_start()
+        monkeypatch.setattr(start_mod, "read_title", utils.read_title)
+        monkeypatch.setattr(start_mod, "write_title", utils.write_title)
+        monkeypatch.setattr(start_mod, "set_iterm2_tab", lambda t: None)
+        monkeypatch.setattr(
+            start_mod,
+            "get_branch_name",
+            lambda cwd: "feat/login",
+        )
+
+        stdin_data = json.dumps({"session_id": "s1", "cwd": "/project"})
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        start_mod.main()
+
+        output = json.loads(stdout_capture.getvalue())
+        assert "feat/login" in output["hookSpecificOutput"]["additionalContext"]
+
+        # Verify title was written
+        title, source = utils.read_title("s1")
+        assert title == "feat/login"
+        assert source == "branch"
+
+    def test_resume_session_keeps_existing_title(self, tmp_path, monkeypatch):
+        """Existing title is not overwritten on resume."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        utils.write_title("s2", "Custom Title", "ai")
+
+        start_mod = _load_session_start()
+        monkeypatch.setattr(start_mod, "read_title", utils.read_title)
+        monkeypatch.setattr(start_mod, "write_title", utils.write_title)
+        monkeypatch.setattr(start_mod, "set_iterm2_tab", lambda t: None)
+
+        stdin_data = json.dumps({"session_id": "s2", "cwd": "/project"})
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        start_mod.main()
+
+        output = json.loads(stdout_capture.getvalue())
+        assert "Custom Title" in output["hookSpecificOutput"]["additionalContext"]
+        assert "source: ai" in output["hookSpecificOutput"]["additionalContext"]
+
+        # Verify title was NOT overwritten
+        title, source = utils.read_title("s2")
+        assert title == "Custom Title"
+        assert source == "ai"
+
+    def test_empty_session_id_no_output(self, monkeypatch):
+        """Empty session_id produces no output."""
+        start_mod = _load_session_start()
+
+        stdin_data = json.dumps({"session_id": "", "cwd": "/project"})
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        start_mod.main()
+
+        assert stdout_capture.getvalue() == ""
+
+
+# =============================================================================
+# C. prompt-title-check.py (3 tests)
+# =============================================================================
+
+
+class TestPromptTitleCheck:
+    """Tests for UserPromptSubmit title injection hook."""
+
+    def test_skips_ai_source(self, tmp_path, monkeypatch):
+        """Source=ai skips immediately with no output."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        utils.write_title("s3", "AI Title", "ai")
+
+        check_mod = _load_prompt_check()
+        monkeypatch.setattr(check_mod, "read_title", utils.read_title)
+
+        stdin_data = json.dumps(
+            {"session_id": "s3", "transcript_path": "/fake/path"}
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        check_mod.main()
+
+        assert stdout_capture.getvalue() == ""
+
+    def test_skips_fewer_than_2_messages(self, tmp_path, monkeypatch):
+        """Only 1 user message — skips title injection."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        utils.write_title("s4", "branch-title", "branch")
+
+        # Create transcript with 1 message
+        transcript = tmp_path / "transcript.jsonl"
+        transcript.write_text(json.dumps({"type": "human", "message": "hello"}))
+
+        check_mod = _load_prompt_check()
+        monkeypatch.setattr(check_mod, "read_title", utils.read_title)
+
+        stdin_data = json.dumps(
+            {"session_id": "s4", "transcript_path": str(transcript)}
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        check_mod.main()
+
+        assert stdout_capture.getvalue() == ""
+
+    def test_injects_title_instruction(self, tmp_path, monkeypatch):
+        """2+ messages with branch source triggers title injection."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        utils.write_title("s5", "main", "branch")
+
+        # Create transcript with 2 messages
+        transcript = tmp_path / "transcript.jsonl"
+        lines = [
+            json.dumps({"type": "human", "message": "fix the bug"}),
+            json.dumps({"type": "human", "message": "add tests"}),
+        ]
+        transcript.write_text("\n".join(lines))
+
+        check_mod = _load_prompt_check()
+        monkeypatch.setattr(check_mod, "read_title", utils.read_title)
+
+        stdin_data = json.dumps(
+            {"session_id": "s5", "transcript_path": str(transcript)}
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        check_mod.main()
+
+        output = json.loads(stdout_capture.getvalue())
+        ctx = output["hookSpecificOutput"]["additionalContext"]
+        assert "Session Title Request" in ctx
+        assert "s5" in ctx
+
+
+# =============================================================================
+# D. statusline.py (2 tests)
+# =============================================================================
+
+
+class TestStatusLine:
+    """Tests for StatusLine display script."""
+
+    def test_displays_title_with_model_and_context(self, tmp_path, monkeypatch):
+        """Title + model + context percentage in output."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+        utils.write_title("s6", "Debug Auth Flow", "ai")
+
+        sl_mod = _load_statusline()
+        monkeypatch.setattr(sl_mod, "read_title", utils.read_title)
+        monkeypatch.setattr(sl_mod, "set_iterm2_tab", lambda t: None)
+
+        stdin_data = json.dumps(
+            {
+                "session_id": "s6",
+                "cwd": "/project",
+                "model": {"display_name": "Opus"},
+                "context_window": {"used_percentage": 42},
+            }
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        sl_mod.main()
+
+        line = stdout_capture.getvalue().strip()
+        assert "[Debug Auth Flow]" in line
+        assert "Opus" in line
+        assert "42%" in line
+
+    def test_fallback_to_branch_name(self, tmp_path, monkeypatch):
+        """No title file — falls back to branch name."""
+        monkeypatch.setattr(utils, "TITLES_DIR", tmp_path)
+
+        sl_mod = _load_statusline()
+        monkeypatch.setattr(sl_mod, "read_title", utils.read_title)
+        monkeypatch.setattr(sl_mod, "set_iterm2_tab", lambda t: None)
+        monkeypatch.setattr(sl_mod, "get_branch_name", lambda cwd: "develop")
+
+        stdin_data = json.dumps(
+            {
+                "session_id": "s7",
+                "cwd": "/project",
+                "model": {"display_name": "Sonnet"},
+                "context_window": {"used_percentage": 10},
+            }
+        )
+        monkeypatch.setattr("sys.stdin", io.StringIO(stdin_data))
+
+        stdout_capture = io.StringIO()
+        monkeypatch.setattr("sys.stdout", stdout_capture)
+
+        sl_mod.main()
+
+        line = stdout_capture.getvalue().strip()
+        assert "[develop]" in line
+        assert "Sonnet" in line


### PR DESCRIPTION
<!-- summary-bot-start -->
> 🎭 *AIポエムサマリー*
>
> 並列ワークツリーの迷宮から脱獄する物語、
> ブランチ名がiTerm2タブに刻まれ、
> ユーザーの声二つでAIがトピックを紡ぎ出し、
> ステータスラインに `[タイトル] | モデル | ctx%` と灯る。
> /titleコマンドで手動の誇りも許しながら、
> 12のテストが冪等デプロイの約束を守る。

---
<!-- summary-bot-end -->

## 概要

5-6個の並列ワークツリーを使用する際、どのターミナルがどのタスクに対応しているか識別困難な問題を解決します。

### 実装コンポーネント

- **SessionStart hook**: セッション開始時にブランチ名からiTerm2タブタイトルを自動設定。リジュームでは既存タイトルを復元
- **UserPromptSubmit hook**: ユーザーメッセージ2件以上で、AIタイトル生成を注入（source=branch の場合のみ）
- **StatusLine スクリプト**: `[タイトル] | モデル名 | ctx%` をClaude Codeステータスバーに常時表示
- **/title スキル**: 手動でタイトルを設定・再生成するコマンド
- **install.sh**: `~/.claude/` への冪等デプロイ（settings.jsonの安全なマージ付き）
- **12件のpytestテスト**: utils, hooks, statusline の網羅的テスト

### タイトル遷移フロー

```
新規セッション → ブランチ名 (source: branch)
    ↓ (ユーザーメッセージ2件以上)
AI生成タイトル → トピック名 (source: ai)
    ↓ (/title コマンド実行)
手動オーバーライド → カスタムタイトル (source: manual)
```

### 変更ファイル一覧

| アクション | パス |
|---|---|
| 新規 | `src/session-title/session_title_utils.py` |
| 新規 | `src/session-title/session-start-title.py` |
| 新規 | `src/session-title/prompt-title-check.py` |
| 新規 | `src/session-title/statusline.py` |
| 新規 | `src/session-title/install.sh` |
| 新規 | `.claude/skills/title/SKILL.md` |
| 新規 | `tests/test_session_title.py` |
| 変更 | `Makefile` |
| 変更 | `pytest.ini` |
| 変更 | `package.json` |
| 変更 | `.github/workflows/test.yml` |
| 変更 | `.github/workflows/lint.yml` |

## テスト計画

- [x] `make test-python` — 12/12 テスト合格
- [x] CI（lint + test）通過
- [x] `make install-session-title` — `~/.claude/` に正しくデプロイ
- [ ] 新セッション → iTerm2タブにブランチ名表示
- [ ] 2件以上のメッセージ後 → AIがトピックベースのタイトル生成
- [ ] `/title My Title` → 手動オーバーライド動作

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)