### PR TITLE
feat(#102): 自動issue作成時の重複チェック

### DIFF
--- a/scripts/check-duplicate-issue.sh
+++ b/scripts/check-duplicate-issue.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# check-duplicate-issue.sh
+# Usage: check-duplicate-issue.sh "keyword1 keyword2"
+# Searches open issues for potential duplicates before creating a new issue.
+# Exit code 0 = no duplicates found (safe to create)
+# Exit code 1 = duplicates found (do NOT create)
+
+set -euo pipefail
+
+REPO="${REPO:-miyashita337/claude-context-manager}"
+QUERY="${1:-}"
+
+if [[ -z "$QUERY" ]]; then
+    echo "Usage: $0 \"keyword1 keyword2\"" >&2
+    exit 2
+fi
+
+echo "Searching for potential duplicate issues: \"$QUERY\""
+echo "Repository: $REPO"
+echo ""
+
+RESULTS=$(gh issue list \
+    --state open \
+    --search "$QUERY" \
+    --repo "$REPO" \
+    --limit 10 \
+    --json number,title,url \
+    --jq '.[] | "#\(.number) \(.title)\n  \(.url)"')
+
+if [[ -z "$RESULTS" ]]; then
+    echo "No duplicates found. Safe to create a new issue."
+    exit 0
+else
+    echo "Potential duplicate issues found:"
+    echo ""
+    echo "$RESULTS"
+    echo ""
+    echo "If any of the above match your intent, do NOT create a new issue."
+    echo "Add a comment to the existing issue instead."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- `scripts/check-duplicate-issue.sh` を追加
- `gh issue create` 実行前にキーワード検索で既存issueの重複を確認する
- 重複あり: exit 1（作成しない）、重複なし: exit 0（作成可）

## Usage

```bash
bash scripts/check-duplicate-issue.sh "keyword1 keyword2"
```

## Test plan

- [ ] キーワードに一致するopen issueがある場合 → exit 1 + 一覧表示
- [ ] 一致するissueがない場合 → exit 0 + "No duplicates found" 表示
- [ ] 引数なしで実行 → exit 2 + usage 表示

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューア**
  * GitHub イシューの重複チェック機能を新たに追加しました。キーワードベースの検索によって既存のオープンイシュー内から潜在的な重複を自動検出できるようになります。新規イシュー作成前の確認にご活用ください。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->