### PR TITLE
feat: scheduled Pushover reports (Daily/Weekly 19:00 JST)

### DIFF
--- a/src/monitor/entry.py
+++ b/src/monitor/entry.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
-"""Lightweight entry point for hook-based monitoring."""
+"""Lightweight entry point for hook-based monitoring and scheduled reports."""
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timedelta
+from io import StringIO
 
+from src.analyzer.aggregator import Aggregator, ProjectSummary
 from src.analyzer.ccusage_client import CcusageClient
+from src.analyzer.merger import Merger
+from src.analyzer.project_mapper import ProjectMapper
+from src.cache.scan_cache import ScanCache
 from src.config.usage_config import UsageConfig
-from src.monitor.notifier import notify_alerts
+from src.monitor.notifier import notify_alerts, send_pushover
 from src.monitor.threshold import ThresholdChecker
+from src.output.cli_report import CliReporter
+
+from pathlib import Path
+
+CACHE_DIR = Path.home() / ".claude" / "tools" / "token-analyzer" / ".cache"
 
 
 def check_session() -> int:
@@ -29,13 +40,120 @@ def check_session() -> int:
     return 0
 
 
+def _generate_report(
+    since: str | None = None, top: int = 10
+) -> tuple[str, dict[str, float] | None]:
+    """Generate token usage report text and cost map."""
+    mapper = ProjectMapper()
+    cache = ScanCache(CACHE_DIR / "scan_cache.json")
+    aggregator = Aggregator(mapper=mapper, scan_cache=cache)
+    summaries = aggregator.aggregate()
+
+    costs: dict[str, float] | None = None
+    client = CcusageClient(timeout=15)
+    ccusage_result = client.fetch(since=since)
+    if ccusage_result:
+        costs = ccusage_result.get_project_costs(username=mapper.username)
+
+    merger = Merger()
+    merged = merger.merge(summaries, costs)
+    ranked = sorted(merged.items(), key=lambda x: x[1].total_tokens, reverse=True)[:top]
+
+    report_data: list[tuple[str, ProjectSummary]] = []
+    cost_map: dict[str, float] = {}
+    for name, ms in ranked:
+        ps = ProjectSummary(
+            input_tokens=ms.input_tokens,
+            output_tokens=ms.output_tokens,
+            cache_creation_tokens=ms.cache_creation_tokens,
+            cache_read_tokens=ms.cache_read_tokens,
+            session_count=ms.session_count,
+            models_used=ms.models_used,
+        )
+        report_data.append((name, ps))
+        if ms.cost_usd is not None:
+            cost_map[name] = ms.cost_usd
+
+    output = StringIO()
+    reporter = CliReporter(output=output)
+    reporter.render(report_data, costs=cost_map if cost_map else None)
+
+    cache.save()
+    return output.getvalue(), cost_map
+
+
+def report_daily() -> int:
+    """Generate and send daily token usage report via Pushover."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    since = datetime.now().strftime("%Y%m%d")
+
+    report_text, cost_map = _generate_report(since=since, top=10)
+
+    total_cost = sum(cost_map.values()) if cost_map else 0
+    cost_str = f"~${total_cost:.2f}" if cost_map else "N/A"
+
+    title = f"📊 Daily Token Report ({today})"
+    message = f"Total: {cost_str}\n\n{report_text[:900]}"
+
+    success = send_pushover(title, message)
+    if success:
+        print(f"Daily report sent: {today}")
+    else:
+        print(f"Failed to send daily report: {today}")
+        print(report_text)
+    return 0 if success else 1
+
+
+def report_weekly() -> int:
+    """Generate and send weekly token usage report via Pushover."""
+    today = datetime.now()
+    week_ago = today - timedelta(days=7)
+    since = week_ago.strftime("%Y%m%d")
+    period = f"{week_ago.strftime('%m/%d')}–{today.strftime('%m/%d')}"
+
+    report_text, cost_map = _generate_report(since=since, top=10)
+
+    total_cost = sum(cost_map.values()) if cost_map else 0
+    cost_str = f"~${total_cost:.2f}" if cost_map else "N/A"
+
+    title = f"📊 Weekly Token Report ({period})"
+    message = f"Total: {cost_str}\n\n{report_text[:900]}"
+
+    success = send_pushover(title, message)
+    if success:
+        print(f"Weekly report sent: {period}")
+    else:
+        print(f"Failed to send weekly report: {period}")
+        print(report_text)
+    return 0 if success else 1
+
+
+def report_test() -> int:
+    """Send a test notification to verify Pushover is working."""
+    title = "🔔 Token Analyzer Test"
+    message = "テスト通知です。Token Analyzerの定期レポート機能が正常に動作しています。"
+    success = send_pushover(title, message)
+    if success:
+        print("Test notification sent successfully!")
+    else:
+        print("Test notification FAILED. Check Pushover configuration.")
+    return 0 if success else 1
+
+
 def main() -> int:
     if len(sys.argv) < 2:
-        print("Usage: entry.py <check-session|report-daily|report-weekly>")
+        print("Usage: entry.py <check-session|report-daily|report-weekly|report-test>")
         return 1
     command = sys.argv[1]
-    if command == "check-session":
-        return check_session()
+    commands = {
+        "check-session": check_session,
+        "report-daily": report_daily,
+        "report-weekly": report_weekly,
+        "report-test": report_test,
+    }
+    handler = commands.get(command)
+    if handler:
+        return handler()
     print(f"Unknown command: {command}")
     return 1
 

--- a/src/output/cli_report.py
+++ b/src/output/cli_report.py
@@ -32,11 +32,10 @@ class CliReporter:
 
         costs = costs or {}
 
-        header = f"{'#':>3}  {'Project':<35}  {'Sessions':>8}  {'Total Tokens':>14}  {'Cost (USD)':>12}\n"
-        separator = "-" * len(header.rstrip()) + "\n"
+        header = f"{'#':>2} {'Project':<20} {'Ses':>3} {'Tokens':>8} {'Cost':>8}\n"
+        separator = "-" * 45 + "\n"
 
-        self.output.write("\nToken Usage Report (Local CLI)\n")
-        self.output.write("* Cost is approximate (via ccusage)\n\n")
+        self.output.write("Token Usage (Local CLI)\n")
         self.output.write(header)
         self.output.write(separator)
 
@@ -45,19 +44,20 @@ class CliReporter:
 
         for i, (name, summary) in enumerate(data, 1):
             cost = costs.get(name)
-            cost_str = f"~${cost:.2f}" if cost is not None else "N/A"
+            cost_str = f"${cost:.0f}" if cost is not None else "-"
             tokens_str = self.format_tokens(summary.total_tokens)
             total_tokens += summary.total_tokens
             if cost is not None:
                 total_cost += cost
+            # Truncate long project names
+            display_name = name[:20] if len(name) > 20 else name
             self.output.write(
-                f"{i:>3}  {name:<35}  {summary.session_count:>8}  {tokens_str:>14}  {cost_str:>12}\n"
+                f"{i:>2} {display_name:<20} {summary.session_count:>3} {tokens_str:>8} {cost_str:>8}\n"
             )
 
         self.output.write(separator)
         total_tokens_str = self.format_tokens(total_tokens)
-        total_cost_str = f"~${total_cost:.2f}" if costs else "N/A"
+        total_cost_str = f"${total_cost:.0f}" if costs else "-"
         self.output.write(
-            f"{'':>3}  {'Total':<35}  {'':>8}  {total_tokens_str:>14}  {total_cost_str:>12}\n"
+            f"   {'Total':<20} {'':>3} {total_tokens_str:>8} {total_cost_str:>8}\n"
         )
-        self.output.write("\n")

--- a/tests/test_cli_report.py
+++ b/tests/test_cli_report.py
@@ -70,7 +70,7 @@ class TestCliReporter:
         reporter = CliReporter(output=output)
         reporter.render(data, costs=costs)
         result = output.getvalue()
-        assert "$12.34" in result
+        assert "$12" in result
 
     def test_render_empty(self) -> None:
         output = StringIO()


### PR DESCRIPTION
## Summary

- `report-daily` / `report-weekly` / `report-test` コマンドを entry.py に追加
- Pushover向けコンパクトレイアウト（45文字幅、プロジェクト名20文字、コスト整数表示）
- テスト通知3通で動作確認済み

## Test plan
- [x] `report-test` — テスト通知送信OK
- [x] `report-daily` — Daily送信OK、Pushover表示確認済み
- [x] `report-weekly` — Weekly送信OK
- [x] レイアウト修正後のユーザー確認OK
- [x] pytest 6/6 pass

Closes #116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 日次・週次スケジュール済みトークン使用レポートを追加
  * テストレポート送信機能を追加

* **スタイル**
  * レポート表示形式を最適化し、テーブルレイアウトを改善
  * コスト表示を整数ドル形式に変更

* **テスト**
  * レポート出力テストを新しいコスト形式に対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->