### PR TITLE
fix: suppress dialog when P2 judgment fails

### DIFF
--- a/src/hooks/user-prompt-submit.py
+++ b/src/hooks/user-prompt-submit.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 # Add shared directory to Python path
-sys.path.insert(0, str(Path(__file__).parent / 'shared'))
+sys.path.insert(0, str(Path(__file__).parent / "shared"))
 
 from logger import SessionLogger
 
@@ -21,41 +21,123 @@ from logger import SessionLogger
 # Must NOT appear together with tech keywords to trigger warning
 _OFF_TOPIC = [
     # 天気・気象
-    '天気', '気温', '台風', '気候', '天候', '晴れ', '曇り', '降水',
+    "天気",
+    "気温",
+    "台風",
+    "気候",
+    "天候",
+    "晴れ",
+    "曇り",
+    "降水",
     # ニュース・時事・政治
-    'ニュース', '時事', '政治', '選挙', '事件', '事故', '芸能',
+    "ニュース",
+    "時事",
+    "政治",
+    "選挙",
+    "事件",
+    "事故",
+    "芸能",
     # 金融・株式
-    '株価', '為替', '仮想通貨', 'bitcoin', 'btc', '投資信託',
+    "株価",
+    "為替",
+    "仮想通貨",
+    "bitcoin",
+    "btc",
+    "投資信託",
     # 料理・食事
-    'レシピ', '食べ物', 'ランチ', 'ディナー', '献立', '食材',
+    "レシピ",
+    "食べ物",
+    "ランチ",
+    "ディナー",
+    "献立",
+    "食材",
     # エンタメ・雑談
-    'アニメ', 'マンガ', 'スポーツ', '野球', 'サッカー', '競馬',
+    "アニメ",
+    "マンガ",
+    "スポーツ",
+    "野球",
+    "サッカー",
+    "競馬",
 ]
 
 # Tech/work-related keywords that override off-topic detection
 _TECH = [
     # コーディング全般
-    'コード', '実装', 'バグ', 'エラー', 'デバッグ', 'テスト', 'リファクタ',
-    'ファイル', '関数', 'クラス', 'メソッド', 'モジュール', 'ライブラリ',
+    "コード",
+    "実装",
+    "バグ",
+    "エラー",
+    "デバッグ",
+    "テスト",
+    "リファクタ",
+    "ファイル",
+    "関数",
+    "クラス",
+    "メソッド",
+    "モジュール",
+    "ライブラリ",
     # Git / CI
-    'git', 'commit', 'push', 'pull', 'branch', 'merge', 'pr', 'issue',
+    "git",
+    "commit",
+    "push",
+    "pull",
+    "branch",
+    "merge",
+    "pr",
+    "issue",
     # 言語・フレームワーク
-    'python', 'typescript', 'javascript', 'bash', 'shell', 'sql',
-    'api', 'json', 'yaml', 'toml', 'hook', 'cli', 'sdk',
+    "python",
+    "typescript",
+    "javascript",
+    "bash",
+    "shell",
+    "sql",
+    "api",
+    "json",
+    "yaml",
+    "toml",
+    "hook",
+    "cli",
+    "sdk",
     # 作業動詞
-    'インストール', '設定', 'ビルド', 'デプロイ', '修正', '追加', '削除',
-    'import', 'def ', 'class ', 'return', 'fix', 'feat', 'refactor',
+    "インストール",
+    "設定",
+    "ビルド",
+    "デプロイ",
+    "修正",
+    "追加",
+    "削除",
+    "import",
+    "def ",
+    "class ",
+    "return",
+    "fix",
+    "feat",
+    "refactor",
     # このプロジェクト固有
-    'セッション', 'analytics', 'hook', 'claude', 'llm', 'token',
+    "セッション",
+    "analytics",
+    "hook",
+    "claude",
+    "llm",
+    "token",
 ]
 
 # Question scatter detection markers (Issue #96)
 _QUESTION_MARKERS = [
-    '？', '?',
-    'なぜ', 'どうして', 'なんで',
-    'どう違う', '違いは', '比較',
-    'それぞれ', '各々',
-    'あと、', 'ついでに', 'もう一つ',
+    "？",
+    "?",
+    "なぜ",
+    "どうして",
+    "なんで",
+    "どう違う",
+    "違いは",
+    "比較",
+    "それぞれ",
+    "各々",
+    "あと、",
+    "ついでに",
+    "もう一つ",
 ]
 
 
@@ -66,7 +148,7 @@ def read_user_messages(transcript_path: str) -> list[str]:
         return []
     messages = []
     try:
-        with open(path, errors='replace') as f:
+        with open(path, errors="replace") as f:
             for line in f:
                 line = line.strip()
                 if not line:
@@ -75,8 +157,8 @@ def read_user_messages(transcript_path: str) -> list[str]:
                     event = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                if event.get('type') == 'user':
-                    content = event.get('message', {}).get('content', '')
+                if event.get("type") == "user":
+                    content = event.get("message", {}).get("content", "")
                     if isinstance(content, str) and content.strip():
                         messages.append(content[:300])
     except Exception:
@@ -94,18 +176,24 @@ def _query_topic_server(prompt: str, session_id: str, transcript_path: str) -> d
     import http.client
 
     all_messages = read_user_messages(transcript_path)
-    baseline_messages = all_messages[:3]   # first 3 = session intent
+    baseline_messages = all_messages[:3]  # first 3 = session intent
 
-    payload = json.dumps({
-        "prompt": prompt,
-        "session_id": session_id,
-        "baseline_messages": baseline_messages,
-    }).encode()
+    payload = json.dumps(
+        {
+            "prompt": prompt,
+            "session_id": session_id,
+            "baseline_messages": baseline_messages,
+        }
+    ).encode()
 
     try:
         conn = http.client.HTTPConnection("127.0.0.1", 8765, timeout=2)
-        conn.request("POST", "/similarity", body=payload,
-                     headers={"Content-Type": "application/json"})
+        conn.request(
+            "POST",
+            "/similarity",
+            body=payload,
+            headers={"Content-Type": "application/json"},
+        )
         resp = conn.getresponse()
         data = json.loads(resp.read())
         conn.close()
@@ -120,7 +208,7 @@ def detect_topic_deviation(current_prompt: str, recent_messages: list[str]) -> d
     Returns:
         {"is_deviation": bool, "reason": str}
     """
-    text = (current_prompt + ' ' + ' '.join(recent_messages)).lower()
+    text = (current_prompt + " " + " ".join(recent_messages)).lower()
     prompt_lower = current_prompt.lower()
 
     # Tech keyword present → always PASS (prevents false positives like "天気予報APIの実装")
@@ -141,7 +229,7 @@ def detect_topic_deviation(current_prompt: str, recent_messages: list[str]) -> d
 
 def detect_question_scatter(prompt: str) -> dict:
     """Detect question scatter pattern (multiple independent questions in one prompt)."""
-    question_marks = prompt.count('？') + prompt.count('?')
+    question_marks = prompt.count("？") + prompt.count("?")
     marker_count = sum(1 for m in _QUESTION_MARKERS if m in prompt)
     if question_marks >= 3 or marker_count >= 4:
         return {"is_scatter": True, "question_count": max(question_marks, marker_count)}
@@ -157,7 +245,7 @@ def compute_question_density(transcript_path: str, window: int = 5) -> float:
     recent = messages[-window:]
     if not recent:
         return 0.0
-    total_questions = sum(m.count('？') + m.count('?') for m in recent)
+    total_questions = sum(m.count("？") + m.count("?") for m in recent)
     return total_questions / len(recent)
 
 
@@ -177,7 +265,7 @@ def sanitize_stdin(stdin_content: str, hook_name: str) -> str:
     # Find first JSON character
     start_idx = -1
     for i, char in enumerate(stdin_content):
-        if char in ('{', '['):
+        if char in ("{", "["):
             start_idx = i
             break
 
@@ -187,9 +275,9 @@ def sanitize_stdin(stdin_content: str, hook_name: str) -> str:
 
     # Non-JSON text found before JSON - sanitize and log
     if start_idx > 0:
-        debug_log = Path.home() / '.claude' / 'hook-debug.log'
+        debug_log = Path.home() / ".claude" / "hook-debug.log"
         try:
-            with open(debug_log, 'a', encoding='utf-8') as f:
+            with open(debug_log, "a", encoding="utf-8") as f:
                 f.write(f"\n=== Stdin Sanitization ({hook_name}) ===\n")
                 f.write(f"Removed {start_idx} bytes of non-JSON prefix\n")
                 f.write(f"Prefix content: {repr(stdin_content[:start_idx])}\n")
@@ -203,9 +291,9 @@ def sanitize_stdin(stdin_content: str, hook_name: str) -> str:
 
 def _p2_debug_log(msg: str) -> None:
     """Write a debug message to hook-debug.log (best-effort)."""
-    debug_log = Path.home() / '.claude' / 'hook-debug.log'
+    debug_log = Path.home() / ".claude" / "hook-debug.log"
     try:
-        with open(debug_log, 'a', encoding='utf-8') as f:
+        with open(debug_log, "a", encoding="utf-8") as f:
             f.write(f"\n=== P2 Debug ===\n{msg}\n")
     except Exception:
         pass
@@ -226,7 +314,11 @@ def _query_llm_p2(prompt: str, baseline_messages: list[str]) -> dict:
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
-        return {"decision": "warn", "reason": "p2_unavailable (no API key)", "judgment_failed": True}
+        return {
+            "decision": "warn",
+            "reason": "p2_unavailable (no API key)",
+            "judgment_failed": True,
+        }
 
     _SYSTEM_PROMPT = (
         "You are evaluating whether a user's new prompt is off-topic for their current work session.\n\n"
@@ -252,18 +344,20 @@ def _query_llm_p2(prompt: str, baseline_messages: list[str]) -> dict:
         "Is this new prompt on-topic for the session?"
     )
 
-    payload = json.dumps({
-        "model": "claude-haiku-4-5-20251001",
-        "max_tokens": 60,
-        "system": [
-            {
-                "type": "text",
-                "text": _SYSTEM_PROMPT,
-                "cache_control": {"type": "ephemeral"},
-            }
-        ],
-        "messages": [{"role": "user", "content": user_content}],
-    }).encode()
+    payload = json.dumps(
+        {
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 60,
+            "system": [
+                {
+                    "type": "text",
+                    "text": _SYSTEM_PROMPT,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            "messages": [{"role": "user", "content": user_content}],
+        }
+    ).encode()
 
     req = urllib.request.Request(
         "https://api.anthropic.com/v1/messages",
@@ -278,49 +372,83 @@ def _query_llm_p2(prompt: str, baseline_messages: list[str]) -> dict:
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=5) as resp:  # nosemgrep: dynamic-urllib-use-detected
+        with urllib.request.urlopen(
+            req, timeout=5
+        ) as resp:  # nosemgrep: dynamic-urllib-use-detected
             resp_body = resp.read()
     except urllib.error.HTTPError as e:
-        return {"decision": "warn", "reason": f"p2_api_error ({e.code})", "judgment_failed": True}
+        return {
+            "decision": "warn",
+            "reason": f"p2_api_error ({e.code})",
+            "judgment_failed": True,
+        }
     except Exception as e:
         _p2_debug_log(f"urlopen raised {type(e).__name__}: {e}")
-        return {"decision": "warn", "reason": f"p2_error: {str(e)[:50]}", "judgment_failed": True}
+        return {
+            "decision": "warn",
+            "reason": f"p2_error: {str(e)[:50]}",
+            "judgment_failed": True,
+        }
 
     if not resp_body or not resp_body.strip():
         return {"decision": "warn", "reason": "p2_empty_body", "judgment_failed": True}
 
     # Guard: non-JSON body (e.g. HTML from WAF/CDN returning 200 with error page)
-    if not resp_body.strip().startswith((b'{', b'[')):
-        return {"decision": "warn", "reason": "p2_non_json_body", "judgment_failed": True}
+    if not resp_body.strip().startswith((b"{", b"[")):
+        return {
+            "decision": "warn",
+            "reason": "p2_non_json_body",
+            "judgment_failed": True,
+        }
 
     try:
         data = json.loads(resp_body)
         content_list = data.get("content", [])
         if not content_list:
-            return {"decision": "warn", "reason": "p2_empty_response", "judgment_failed": True}
+            return {
+                "decision": "warn",
+                "reason": "p2_empty_response",
+                "judgment_failed": True,
+            }
 
         text = content_list[0].get("text", "")
         if not text.strip():
-            return {"decision": "warn", "reason": "p2_empty_text", "judgment_failed": True}
+            return {
+                "decision": "warn",
+                "reason": "p2_empty_text",
+                "judgment_failed": True,
+            }
 
         # Guard: Haiku returned prose instead of JSON (e.g. "I cannot determine...")
-        if not text.strip().startswith(('{', '[')):
-            return {"decision": "warn", "reason": "p2_non_json_text", "judgment_failed": True}
+        if not text.strip().startswith(("{", "[")):
+            return {
+                "decision": "warn",
+                "reason": "p2_non_json_text",
+                "judgment_failed": True,
+            }
 
         result = json.loads(text.strip())
 
         if result.get("ok", True):  # missing 'ok' → default on-topic (conservative)
             return {"decision": "pass", "reason": "p2_on_topic"}
-        return {"decision": "warn", "reason": f"p2_llm: {result.get('reason', 'off-topic')}"}
+        return {
+            "decision": "warn",
+            "reason": f"p2_llm: {result.get('reason', 'off-topic')}",
+        }
 
     except Exception as e:
         import traceback
+
         _p2_debug_log(
             f"inner parse error {type(e).__name__}: {e}\n"
             f"resp_body[:200]={repr(resp_body[:200])}\n"
             f"traceback:\n{traceback.format_exc()}"
         )
-        return {"decision": "warn", "reason": f"p2_error: {str(e)[:50]}", "judgment_failed": True}
+        return {
+            "decision": "warn",
+            "reason": f"p2_error: {str(e)[:50]}",
+            "judgment_failed": True,
+        }
 
 
 def _run_detection(current_prompt: str, session_id: str, transcript_path: str) -> dict:
@@ -355,11 +483,17 @@ def _run_detection(current_prompt: str, session_id: str, transcript_path: str) -
                         "reason": f"p2_pass ({p2['reason']})",
                     }
                 else:
-                    detection = {
-                        "is_deviation": True,
-                        "reason": p2["reason"],
-                        "judgment_failed": p2.get("judgment_failed", False),
-                    }
+                    # judgment_failed → 判定不能は逸脱扱いしない（ダイアログ抑止）
+                    if p2.get("judgment_failed", False):
+                        detection = {
+                            "is_deviation": False,
+                            "reason": f"p2_judgment_failed_pass ({p2['reason']})",
+                        }
+                    else:
+                        detection = {
+                            "is_deviation": True,
+                            "reason": p2["reason"],
+                        }
     else:
         # P0 fallback: サーバー停止 or baseline未形成（セッション先頭）
         recent = read_user_messages(transcript_path)[-5:]
@@ -376,12 +510,16 @@ def main():
 
         # Handle empty stdin gracefully
         if not stdin_content or not stdin_content.strip():
-            print(json.dumps({
-                "hookSpecificOutput": {
-                    "hookEventName": "UserPromptSubmit",
-                    "status": "skipped"
-                }
-            }))
+            print(
+                json.dumps(
+                    {
+                        "hookSpecificOutput": {
+                            "hookEventName": "UserPromptSubmit",
+                            "status": "skipped",
+                        }
+                    }
+                )
+            )
             sys.exit(0)
 
         # Sanitize stdin (remove non-JSON prefix from shell profile pollution)
@@ -391,58 +529,44 @@ def main():
         input_data = json.loads(stdin_content)
 
         # Extract session ID, user prompt, and transcript path
-        session_id = input_data.get('session_id', 'unknown')
-        user_prompt = input_data.get('prompt', '')
-        transcript_path = input_data.get('transcript_path', '')
+        session_id = input_data.get("session_id", "unknown")
+        user_prompt = input_data.get("prompt", "")
+        transcript_path = input_data.get("transcript_path", "")
 
         # Log the user prompt
         logger = SessionLogger(session_id)
-        logger.add_entry('user', user_prompt)
+        logger.add_entry("user", user_prompt)
 
         # Get session stats
         stats = logger.get_session_stats()
 
         # --- Topic deviation detection: P1 → P0 veto → P2 ---
-        additional_parts = [f"Logged user prompt. Session stats: {stats['total_tokens']} tokens"]
+        additional_parts = [
+            f"Logged user prompt. Session stats: {stats['total_tokens']} tokens"
+        ]
 
         try:
             detection = _run_detection(user_prompt, session_id, transcript_path)
 
             if detection.get("is_deviation"):
                 reason = detection.get("reason", "")
-                judgment_failed = detection.get("judgment_failed", False)
 
                 # プロンプトの冒頭をモーダルに表示（どの発言が引っかかったか識別用）
-                prompt_preview = user_prompt[:40].replace('\n', ' ')
+                prompt_preview = user_prompt[:40].replace("\n", " ")
                 if len(user_prompt) > 40:
                     prompt_preview += "..."
                 prompt_line = f"▶ 「{prompt_preview}」"
 
-                # デフォルト値を先に設定（NameError防止 + 明示的な初期化）
                 alert_title = "🔴 話題逸脱の可能性"
                 alert_message = (
                     "現在のセッションのトピックと関連が薄いかもしれません。\n"
                     "別トピックの場合は新しいセッションの開始を検討してください。\n"
                     f"{prompt_line}"
                 )
-
-                if judgment_failed:
-                    additional_parts.append(
-                        f"🔴🔴🔴 [判定不能] LLMが話題逸脱の判定に失敗しました"
-                        f" ({reason})。念のため確認してください。"
-                    )
-                    alert_title = "⚠️ 話題逸脱：判定不能"
-                    alert_message = (
-                        "LLMが判定できませんでした。\n"
-                        "話題が逸脱している可能性があります。\n"
-                        "念のため確認してください。\n"
-                        f"{prompt_line}"
-                    )
-                else:
-                    additional_parts.append(
-                        f"🔴🔴🔴 [話題逸脱の可能性] 現在のセッションのトピックと関連が薄いかもしれません"
-                        f" ({reason})。別トピックの場合は新しいセッションの開始を検討してください。"
-                    )
+                additional_parts.append(
+                    f"🔴🔴🔴 [話題逸脱の可能性] 現在のセッションのトピックと関連が薄いかもしれません"
+                    f" ({reason})。別トピックの場合は新しいセッションの開始を検討してください。"
+                )
 
                 # AppleScriptモーダルで強制通知（バックグラウンド起動、クリックまで残る）
                 try:
@@ -454,20 +578,20 @@ def main():
                         \n を AppleScript の & return & に変換する。
                         """
                         parts = [
-                            '"' + p.replace('\\', '\\\\').replace('"', '\\"') + '"'
-                            for p in s.split('\n')
+                            '"' + p.replace("\\", "\\\\").replace('"', '\\"') + '"'
+                            for p in s.split("\n")
                         ]
-                        return ' & return & '.join(parts)
+                        return " & return & ".join(parts)
 
                     script = (
-                        f'display alert {_as_str(alert_title)} '
-                        f'message {_as_str(alert_message)} '
+                        f"display alert {_as_str(alert_title)} "
+                        f"message {_as_str(alert_message)} "
                         f'buttons {{"確認"}} '
                         f'default button "確認" '
-                        f'as critical'
+                        f"as critical"
                     )
                     subprocess.Popen(
-                        ['osascript', '-e', script],
+                        ["osascript", "-e", script],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
                         start_new_session=True,
@@ -480,7 +604,9 @@ def main():
         # --- Question scatter detection (independent of topic deviation) ---
         try:
             scatter = detect_question_scatter(user_prompt)
-            density = compute_question_density(transcript_path) if transcript_path else 0.0
+            density = (
+                compute_question_density(transcript_path) if transcript_path else 0.0
+            )
 
             if scatter["is_scatter"] or density > 3.0:
                 parts = []
@@ -505,37 +631,46 @@ def main():
             pass  # 検知失敗はユーザーをブロックしない
 
         # Return success with hookEventName
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
-                "status": "logged",
-                "additionalContext": " | ".join(additional_parts)
-            }
-        }))
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "status": "logged",
+                        "additionalContext": " | ".join(additional_parts),
+                    }
+                }
+            )
+        )
         sys.exit(0)
 
     except Exception as e:
         # Log error but don't fail the hook
         # Write to debug log
-        debug_log = Path.home() / '.claude' / 'hook-debug.log'
+        debug_log = Path.home() / ".claude" / "hook-debug.log"
         try:
-            with open(debug_log, 'a', encoding='utf-8') as f:
+            with open(debug_log, "a", encoding="utf-8") as f:
                 f.write(f"\n=== UserPromptSubmit Error ===\n")
                 f.write(f"ERROR: {str(e)}\n")
                 import traceback
+
                 f.write(f"Traceback: {traceback.format_exc()}\n")
         except:
             pass
 
         # Return error status with hookEventName
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
-                "status": "error"
-            }
-        }))
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "UserPromptSubmit",
+                        "status": "error",
+                    }
+                }
+            )
+        )
         sys.exit(0)  # Don't block user interaction
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/test_user_prompt_submit.py
+++ b/tests/test_user_prompt_submit.py
@@ -40,6 +40,7 @@ compute_question_density = getattr(ups, "compute_question_density", None)
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
+
 def _mock_urlopen(body: dict) -> MagicMock:
     """Return a mock context-manager for urllib.request.urlopen (200 success)."""
     mock_resp = MagicMock()
@@ -64,13 +65,20 @@ def _api_ok(ok: bool, reason: str = "") -> dict:
 
 # ── baseline transcript fixture ───────────────────────────────────────────────
 
+
 @pytest.fixture()
 def transcript(tmp_path) -> str:
     """JSONL transcript with two technical baseline messages."""
     f = tmp_path / "transcript.jsonl"
     lines = [
-        {"type": "user", "message": {"content": "fix the authentication bug in auth.py"}},
-        {"type": "user", "message": {"content": "add unit tests for the login function"}},
+        {
+            "type": "user",
+            "message": {"content": "fix the authentication bug in auth.py"},
+        },
+        {
+            "type": "user",
+            "message": {"content": "add unit tests for the login function"},
+        },
     ]
     f.write_text("\n".join(json.dumps(l) for l in lines))
     return str(f)
@@ -79,6 +87,7 @@ def transcript(tmp_path) -> str:
 # =============================================================================
 # Unit tests: _query_llm_p2()
 # =============================================================================
+
 
 class TestQueryLlmP2:
     """All failure + success paths for the raw API call."""
@@ -106,7 +115,10 @@ class TestQueryLlmP2:
 
     def test_off_topic_returns_warn_with_reason(self):
         """ok:false → decision=warn, reason propagated."""
-        with patch("urllib.request.urlopen", return_value=_mock_urlopen(_api_ok(False, "weather unrelated to work"))):
+        with patch(
+            "urllib.request.urlopen",
+            return_value=_mock_urlopen(_api_ok(False, "weather unrelated to work")),
+        ):
             with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
                 result = ups._query_llm_p2("what's the weather today?", ["fix bug"])
 
@@ -141,7 +153,10 @@ class TestQueryLlmP2:
 
     def test_oserror_returns_warn(self):
         """URLError (connection refused) → warn."""
-        with patch("urllib.request.urlopen", side_effect=urllib.error.URLError("connection refused")):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
             with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
                 result = ups._query_llm_p2("some prompt", [])
 
@@ -161,7 +176,9 @@ class TestQueryLlmP2:
 
     def test_empty_content_array_returns_warn(self):
         """Empty content list → warn."""
-        with patch("urllib.request.urlopen", return_value=_mock_urlopen({"content": []})):
+        with patch(
+            "urllib.request.urlopen", return_value=_mock_urlopen({"content": []})
+        ):
             with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
                 result = ups._query_llm_p2("some prompt", [])
 
@@ -224,7 +241,11 @@ class TestQueryLlmP2:
 
     def test_haiku_returns_prose_not_json(self):
         """Haiku returns prose ('I cannot determine...') instead of JSON → warn, not crash."""
-        body = {"content": [{"type": "text", "text": "I cannot determine if this is off-topic."}]}
+        body = {
+            "content": [
+                {"type": "text", "text": "I cannot determine if this is off-topic."}
+            ]
+        }
         with patch("urllib.request.urlopen", return_value=_mock_urlopen(body)):
             with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "test-key"}):
                 result = ups._query_llm_p2("some prompt", [])
@@ -251,6 +272,7 @@ class TestQueryLlmP2:
 # Integration tests: _run_detection() pipeline trigger conditions
 # =============================================================================
 
+
 class TestRunDetectionPipeline:
     """Verify WHEN P2 fires (and when it must NOT fire)."""
 
@@ -258,7 +280,12 @@ class TestRunDetectionPipeline:
 
     def test_p2_not_called_when_p1_passes(self, transcript):
         """P1 says PASS → P2 skipped."""
-        p1 = {"available": True, "is_deviation": False, "similarity": 0.9, "reason": "ok"}
+        p1 = {
+            "available": True,
+            "is_deviation": False,
+            "similarity": 0.9,
+            "reason": "ok",
+        }
         with patch.object(ups, "_query_topic_server", return_value=p1):
             with patch.object(ups, "_query_llm_p2") as mock_p2:
                 result = ups._run_detection("any prompt", "s1", transcript)
@@ -268,7 +295,12 @@ class TestRunDetectionPipeline:
 
     def test_p2_not_called_when_p0_tech_veto(self, transcript):
         """P1 WARN + P0 sees tech keyword → P2 skipped."""
-        p1 = {"available": True, "is_deviation": True, "similarity": 0.3, "reason": "low"}
+        p1 = {
+            "available": True,
+            "is_deviation": True,
+            "similarity": 0.3,
+            "reason": "low",
+        }
         with patch.object(ups, "_query_topic_server", return_value=p1):
             with patch.object(ups, "_query_llm_p2") as mock_p2:
                 # "python" is a tech keyword → P0 veto
@@ -301,7 +333,12 @@ class TestRunDetectionPipeline:
 
     def test_p2_called_when_p1_warn_no_p0_veto(self, transcript):
         """P1 WARN + no tech keyword + no P0 veto → P2 invoked."""
-        p1 = {"available": True, "is_deviation": True, "similarity": 0.25, "reason": "low"}
+        p1 = {
+            "available": True,
+            "is_deviation": True,
+            "similarity": 0.25,
+            "reason": "low",
+        }
         p2_ret = {"decision": "pass", "reason": "p2_on_topic"}
         with patch.object(ups, "_query_topic_server", return_value=p1):
             with patch.object(ups, "_query_llm_p2", return_value=p2_ret) as mock_p2:
@@ -313,9 +350,18 @@ class TestRunDetectionPipeline:
 
     def test_p2_pass_overrides_p1_warn(self, transcript):
         """P2 says pass → final result is_deviation=False."""
-        p1 = {"available": True, "is_deviation": True, "similarity": 0.3, "reason": "low"}
+        p1 = {
+            "available": True,
+            "is_deviation": True,
+            "similarity": 0.3,
+            "reason": "low",
+        }
         with patch.object(ups, "_query_topic_server", return_value=p1):
-            with patch.object(ups, "_query_llm_p2", return_value={"decision": "pass", "reason": "p2_on_topic"}):
+            with patch.object(
+                ups,
+                "_query_llm_p2",
+                return_value={"decision": "pass", "reason": "p2_on_topic"},
+            ):
                 result = ups._run_detection("今日の天気は？", "s1", transcript)
 
         assert not result["is_deviation"]
@@ -323,19 +369,60 @@ class TestRunDetectionPipeline:
 
     def test_p2_warn_keeps_deviation_true(self, transcript):
         """P2 says warn → is_deviation stays True, reason updated."""
-        p1 = {"available": True, "is_deviation": True, "similarity": 0.2, "reason": "low"}
+        p1 = {
+            "available": True,
+            "is_deviation": True,
+            "similarity": 0.2,
+            "reason": "low",
+        }
         with patch.object(ups, "_query_topic_server", return_value=p1):
-            with patch.object(ups, "_query_llm_p2", return_value={"decision": "warn", "reason": "p2_llm: 天気は無関係"}):
+            with patch.object(
+                ups,
+                "_query_llm_p2",
+                return_value={"decision": "warn", "reason": "p2_llm: 天気は無関係"},
+            ):
                 result = ups._run_detection("今日の天気は？", "s1", transcript)
 
         assert result["is_deviation"]
         assert "p2_llm" in result["reason"]
 
-    def test_p2_error_preserves_p1_warn(self, transcript):
-        """P2 internal error (conservative) → still warns."""
-        p1 = {"available": True, "is_deviation": True, "similarity": 0.2, "reason": "low"}
+    def test_p2_judgment_failed_passes(self, transcript):
+        """P2 judgment_failed → treat as pass (don't interrupt user with dialog)."""
+        p1 = {
+            "available": True,
+            "is_deviation": True,
+            "similarity": 0.2,
+            "reason": "low",
+        }
         with patch.object(ups, "_query_topic_server", return_value=p1):
-            with patch.object(ups, "_query_llm_p2", return_value={"decision": "warn", "reason": "p2_error: timeout"}):
+            with patch.object(
+                ups,
+                "_query_llm_p2",
+                return_value={
+                    "decision": "warn",
+                    "reason": "p2_error: timeout",
+                    "judgment_failed": True,
+                },
+            ):
+                result = ups._run_detection("今日の天気は？", "s1", transcript)
+
+        assert not result["is_deviation"]
+        assert "p2_judgment_failed_pass" in result["reason"]
+
+    def test_p2_confirmed_warn_keeps_deviation(self, transcript):
+        """P2 confirmed off-topic (no judgment_failed) → is_deviation stays True."""
+        p1 = {
+            "available": True,
+            "is_deviation": True,
+            "similarity": 0.2,
+            "reason": "low",
+        }
+        with patch.object(ups, "_query_topic_server", return_value=p1):
+            with patch.object(
+                ups,
+                "_query_llm_p2",
+                return_value={"decision": "warn", "reason": "p2_llm: 天気は無関係"},
+            ):
                 result = ups._run_detection("今日の天気は？", "s1", transcript)
 
         assert result["is_deviation"]
@@ -345,6 +432,7 @@ class TestRunDetectionPipeline:
 # Unit tests: _query_topic_server()
 # =============================================================================
 
+
 class TestQueryTopicServer:
     """Verify P1 embedding server error handling."""
 
@@ -353,7 +441,9 @@ class TestQueryTopicServer:
         import http.client
 
         mock_resp = MagicMock()
-        mock_resp.read.return_value = b""  # empty body → json.loads("") raises JSONDecodeError
+        mock_resp.read.return_value = (
+            b""  # empty body → json.loads("") raises JSONDecodeError
+        )
 
         with patch.object(http.client, "HTTPConnection") as mock_conn_cls:
             mock_conn_cls.return_value.getresponse.return_value = mock_resp
@@ -379,6 +469,7 @@ class TestQueryTopicServer:
 # Unit tests: detect_question_scatter() — #96
 # =============================================================================
 
+
 class TestDetectQuestionScatter:
     """#96: Question scatter pattern detection."""
 
@@ -395,7 +486,9 @@ class TestDetectQuestionScatter:
         assert result["is_scatter"] is True
 
     def test_four_markers_no_question_marks(self):
-        result = detect_question_scatter("なぜこうなるのか、どうしてこうなのか、比較してほしい、それぞれ教えて")
+        result = detect_question_scatter(
+            "なぜこうなるのか、どうしてこうなのか、比較してほしい、それぞれ教えて"
+        )
         assert result["is_scatter"] is True
 
     def test_ten_question_marks(self):
@@ -421,11 +514,15 @@ class TestDetectQuestionScatter:
         assert result["question_count"] == 0
 
     def test_three_markers_below_threshold(self):
-        result = detect_question_scatter("なぜこうなのか、どうして動かないのか、比較して")
+        result = detect_question_scatter(
+            "なぜこうなのか、どうして動かないのか、比較して"
+        )
         assert result["is_scatter"] is False
 
     def test_url_with_single_question_mark(self):
-        result = detect_question_scatter("https://example.com/search?q=test を見てください")
+        result = detect_question_scatter(
+            "https://example.com/search?q=test を見てください"
+        )
         assert result["is_scatter"] is False
 
     def test_question_count_accuracy(self):
@@ -437,6 +534,7 @@ class TestDetectQuestionScatter:
 # Unit tests: compute_question_density() — #97
 # =============================================================================
 
+
 class TestComputeQuestionDensity:
     """#97: Session cumulative question density tracking."""
 
@@ -445,10 +543,11 @@ class TestComputeQuestionDensity:
         path = tmp_path / "transcript.jsonl"
         lines = []
         for msg in messages:
-            lines.append(json.dumps({
-                "type": "user",
-                "message": {"role": "user", "content": msg}
-            }))
+            lines.append(
+                json.dumps(
+                    {"type": "user", "message": {"role": "user", "content": msg}}
+                )
+            )
         path.write_text("\n".join(lines), encoding="utf-8")
         return str(path)
 
@@ -506,12 +605,15 @@ class TestComputeQuestionDensity:
 # Integration tests: scatter detection in main() — #96/#97
 # =============================================================================
 
+
 class TestScatterIntegration:
     """Integration: scatter detection in main() additionalContext."""
 
     @patch.object(ups, "SessionLogger")
     @patch.object(ups, "_run_detection")
-    def test_scatter_detected_additional_context(self, mock_detection, mock_logger, tmp_path, capsys):
+    def test_scatter_detected_additional_context(
+        self, mock_detection, mock_logger, tmp_path, capsys
+    ):
         """When scatter detected, additionalContext should contain guidance."""
         mock_detection.return_value = {"is_deviation": False, "reason": ""}
         mock_logger_instance = MagicMock()
@@ -521,17 +623,25 @@ class TestScatterIntegration:
         # Create a transcript with high density
         transcript = tmp_path / "t.jsonl"
         transcript.write_text(
-            "\n".join(json.dumps({"type": "user", "message": {"role": "user", "content": "？？？？"}}) for _ in range(5)),
-            encoding="utf-8"
+            "\n".join(
+                json.dumps(
+                    {"type": "user", "message": {"role": "user", "content": "？？？？"}}
+                )
+                for _ in range(5)
+            ),
+            encoding="utf-8",
         )
 
-        input_data = json.dumps({
-            "session_id": "test-session",
-            "prompt": "これは何？どうする？なぜ？",
-            "transcript_path": str(transcript)
-        })
+        input_data = json.dumps(
+            {
+                "session_id": "test-session",
+                "prompt": "これは何？どうする？なぜ？",
+                "transcript_path": str(transcript),
+            }
+        )
 
         from io import StringIO
+
         with patch("sys.stdin", StringIO(input_data)):
             with pytest.raises(SystemExit):
                 ups.main()
@@ -544,7 +654,9 @@ class TestScatterIntegration:
 
     @patch.object(ups, "SessionLogger")
     @patch.object(ups, "_run_detection")
-    def test_no_scatter_no_issue_guidance(self, mock_detection, mock_logger, tmp_path, capsys):
+    def test_no_scatter_no_issue_guidance(
+        self, mock_detection, mock_logger, tmp_path, capsys
+    ):
         """When no scatter, additionalContext should not contain issue guidance."""
         mock_detection.return_value = {"is_deviation": False, "reason": ""}
         mock_logger_instance = MagicMock()
@@ -553,17 +665,22 @@ class TestScatterIntegration:
 
         transcript = tmp_path / "t.jsonl"
         transcript.write_text(
-            json.dumps({"type": "user", "message": {"role": "user", "content": "修正して"}}),
-            encoding="utf-8"
+            json.dumps(
+                {"type": "user", "message": {"role": "user", "content": "修正して"}}
+            ),
+            encoding="utf-8",
         )
 
-        input_data = json.dumps({
-            "session_id": "test-session",
-            "prompt": "バグを修正してください",
-            "transcript_path": str(transcript)
-        })
+        input_data = json.dumps(
+            {
+                "session_id": "test-session",
+                "prompt": "バグを修正してください",
+                "transcript_path": str(transcript),
+            }
+        )
 
         from io import StringIO
+
         with patch("sys.stdin", StringIO(input_data)):
             with pytest.raises(SystemExit):
                 ups.main()


### PR DESCRIPTION
## Summary
- P2 LLM判定失敗時（APIエラー、タイムアウト等）に`judgment_failed=True`の場合、逸脱扱いしないように変更
- これにより「話題逸脱：判定不能」のAppleScriptモーダルダイアログが表示されなくなる
- 確実にoff-topicと判定できた場合のみダイアログを表示

## Test plan
- [x] 全53テスト PASS
- [x] `test_p2_judgment_failed_passes`: judgment_failed時にis_deviation=Falseを確認
- [x] `test_p2_confirmed_warn_keeps_deviation`: 確定的なoff-topic判定は引き続きダイアログ表示

Closes miyashita337/agent-base#10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 判定エンジンの失敗時の処理ロジックを改善し、判定失敗時に適切に判定を完了するよう修正しました。
  * メッセージ表示の一貫性を向上させ、複数の警告表示が重複して表示される問題を解決しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->