### PR TITLE
feat(guardrails): Phase 3 B surface — SessionStart + /guardrails:report

### DIFF
--- a/.claude/hooks/session-start-guardrails.sh
+++ b/.claude/hooks/session-start-guardrails.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SessionStart hook: print last-7-days guardrail summary (only if >0 violations).
+# Also triggers archive of >30day entries. Fail-open: always exit 0.
+set -u
+DIR="$(cd "$(dirname "$0")/../scripts" && pwd)"
+python3 "$DIR/archive_violations.py" >/dev/null 2>&1 || true
+python3 "$DIR/guardrails_report.py" summary --days 7 2>/dev/null || true
+exit 0

--- a/.claude/hooks/session-start-guardrails.sh
+++ b/.claude/hooks/session-start-guardrails.sh
@@ -3,6 +3,14 @@
 # Also triggers archive of >30day entries. Fail-open: always exit 0.
 set -u
 DIR="$(cd "$(dirname "$0")/../scripts" && pwd)"
-python3 "$DIR/archive_violations.py" >/dev/null 2>&1 || true
+STATE_DIR="${HOME}/.claude/guardrails"
+STAMP="${STATE_DIR}/.last_archive_date"
+TODAY="$(date +%Y-%m-%d)"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+if [ ! -f "$STAMP" ] || [ "$(cat "$STAMP" 2>/dev/null)" != "$TODAY" ]; then
+  if python3 "$DIR/archive_violations.py" >/dev/null 2>&1; then
+    echo "$TODAY" > "$STAMP" 2>/dev/null || true
+  fi
+fi
 python3 "$DIR/guardrails_report.py" summary --days 7 2>/dev/null || true
 exit 0

--- a/.claude/scripts/archive-violations.sh
+++ b/.claude/scripts/archive-violations.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Archive violations.jsonl entries older than 30 days into
+# ~/.claude/guardrails/archive/violations-YYYY-MM.jsonl.gz
+# Fail-open: exit 0 on any error.
+set -u
+exec python3 "$(dirname "$0")/archive_violations.py" "$@" 2>/dev/null || exit 0

--- a/.claude/scripts/archive-violations.sh
+++ b/.claude/scripts/archive-violations.sh
@@ -3,4 +3,5 @@
 # ~/.claude/guardrails/archive/violations-YYYY-MM.jsonl.gz
 # Fail-open: exit 0 on any error.
 set -u
-exec python3 "$(dirname "$0")/archive_violations.py" "$@" 2>/dev/null || exit 0
+python3 "$(dirname "$0")/archive_violations.py" "$@" 2>/dev/null || true
+exit 0

--- a/.claude/scripts/archive_violations.py
+++ b/.claude/scripts/archive_violations.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Archive violations.jsonl entries older than 30 days.
+
+Moves old entries into ~/.claude/guardrails/archive/violations-YYYY-MM.jsonl.gz
+and rewrites the source file with only recent entries. Fail-open.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+GUARDRAIL_DIR = Path.home() / ".claude" / "guardrails"
+VIOLATIONS_FILE = GUARDRAIL_DIR / "violations.jsonl"
+ARCHIVE_DIR = GUARDRAIL_DIR / "archive"
+RETENTION_DAYS = 30
+
+
+def _parse_ts(s: str) -> datetime | None:
+    try:
+        return datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def archive(
+    src: Path = VIOLATIONS_FILE,
+    archive_dir: Path = ARCHIVE_DIR,
+    retention_days: int = RETENTION_DAYS,
+    now: datetime | None = None,
+) -> tuple[int, int]:
+    """Return (archived_count, kept_count). Fail-open: returns (0,0) on error."""
+    if not src.exists():
+        return (0, 0)
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=retention_days)
+    kept: list[str] = []
+    by_month: dict[str, list[str]] = {}
+    try:
+        with open(src, encoding="utf-8") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    kept.append(line)
+                    continue
+                ts = _parse_ts(rec.get("ts", ""))
+                if ts is None:
+                    kept.append(line)
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                if ts >= cutoff:
+                    kept.append(line)
+                else:
+                    key = ts.strftime("%Y-%m")
+                    by_month.setdefault(key, []).append(line)
+    except OSError:
+        return (0, 0)
+
+    archived = 0
+    if by_month:
+        try:
+            archive_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return (0, len(kept))
+        for month, lines in by_month.items():
+            out = archive_dir / f"violations-{month}.jsonl.gz"
+            try:
+                with gzip.open(out, "at", encoding="utf-8") as gz:
+                    for line in lines:
+                        gz.write(line + "\n")
+                archived += len(lines)
+            except OSError:
+                continue
+
+    if archived > 0:
+        try:
+            tmp = src.with_suffix(".jsonl.tmp")
+            with open(tmp, "w", encoding="utf-8") as f:
+                for line in kept:
+                    f.write(line + "\n")
+            tmp.replace(src)
+        except OSError:
+            pass
+
+    return (archived, len(kept))
+
+
+def main() -> int:
+    archived, kept = archive()
+    if archived > 0:
+        print(f"[archive] {archived} entries archived, {kept} kept", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/scripts/archive_violations.py
+++ b/.claude/scripts/archive_violations.py
@@ -7,6 +7,8 @@ and rewrites the source file with only recent entries. Fail-open.
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import gzip
 import json
 import sys
@@ -17,6 +19,39 @@ GUARDRAIL_DIR = Path.home() / ".claude" / "guardrails"
 VIOLATIONS_FILE = GUARDRAIL_DIR / "violations.jsonl"
 ARCHIVE_DIR = GUARDRAIL_DIR / "archive"
 RETENTION_DAYS = 30
+
+
+@contextlib.contextmanager
+def _exclusive_lock(target: Path):
+    """Acquire an exclusive cross-process lock on target.lock.
+
+    Shared with src/hooks/guardrail_log.py writer to prevent lost appends
+    while the archiver rewrites the source file. Fail-open: yields even if
+    locking is unavailable.
+    """
+    lock_path = target.with_suffix(target.suffix + ".lock")
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        yield
+        return
+    fh = None
+    try:
+        fh = open(lock_path, "w")
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        except OSError:
+            pass
+        yield
+    except OSError:
+        yield
+    finally:
+        if fh is not None:
+            try:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+            fh.close()
 
 
 def _parse_ts(s: str) -> datetime | None:
@@ -32,66 +67,74 @@ def archive(
     retention_days: int = RETENTION_DAYS,
     now: datetime | None = None,
 ) -> tuple[int, int]:
-    """Return (archived_count, kept_count). Fail-open: returns (0,0) on error."""
+    """Return (archived_count, kept_count). Fail-open: returns (0,0) on error.
+
+    Holds an exclusive lock on src for the entire read/process/write cycle so
+    that concurrent appenders (guardrail_log.py) don't lose lines.
+    """
     if not src.exists():
         return (0, 0)
     if now is None:
         now = datetime.now(timezone.utc)
     cutoff = now - timedelta(days=retention_days)
-    kept: list[str] = []
-    by_month: dict[str, list[str]] = {}
-    try:
-        with open(src, encoding="utf-8") as f:
-            for line in f:
-                line = line.rstrip("\n")
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except json.JSONDecodeError:
-                    kept.append(line)
-                    continue
-                ts = _parse_ts(rec.get("ts", ""))
-                if ts is None:
-                    kept.append(line)
-                    continue
-                if ts.tzinfo is None:
-                    ts = ts.replace(tzinfo=timezone.utc)
-                if ts >= cutoff:
-                    kept.append(line)
-                else:
-                    key = ts.strftime("%Y-%m")
-                    by_month.setdefault(key, []).append(line)
-    except OSError:
-        return (0, 0)
 
-    archived = 0
-    if by_month:
+    with _exclusive_lock(src):
+        kept: list[str] = []
+        by_month: dict[str, list[str]] = {}
         try:
-            archive_dir.mkdir(parents=True, exist_ok=True)
+            with open(src, encoding="utf-8") as f:
+                for line in f:
+                    line = line.rstrip("\n")
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        kept.append(line)
+                        continue
+                    ts = _parse_ts(rec.get("ts", ""))
+                    if ts is None:
+                        kept.append(line)
+                        continue
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    if ts >= cutoff:
+                        kept.append(line)
+                    else:
+                        key = ts.strftime("%Y-%m")
+                        by_month.setdefault(key, []).append(line)
         except OSError:
-            return (0, len(kept))
-        for month, lines in by_month.items():
-            out = archive_dir / f"violations-{month}.jsonl.gz"
+            return (0, 0)
+
+        archived = 0
+        failed_lines: list[str] = []
+        if by_month:
             try:
-                with gzip.open(out, "at", encoding="utf-8") as gz:
-                    for line in lines:
-                        gz.write(line + "\n")
-                archived += len(lines)
+                archive_dir.mkdir(parents=True, exist_ok=True)
             except OSError:
-                continue
+                return (0, len(kept))
+            for month, lines in by_month.items():
+                out = archive_dir / f"violations-{month}.jsonl.gz"
+                try:
+                    with gzip.open(out, "at", encoding="utf-8") as gz:
+                        for line in lines:
+                            gz.write(line + "\n")
+                    archived += len(lines)
+                except OSError:
+                    # Re-add failed-month lines so they are not lost.
+                    failed_lines.extend(lines)
 
-    if archived > 0:
-        try:
-            tmp = src.with_suffix(".jsonl.tmp")
-            with open(tmp, "w", encoding="utf-8") as f:
-                for line in kept:
-                    f.write(line + "\n")
-            tmp.replace(src)
-        except OSError:
-            pass
+        if archived > 0:
+            try:
+                tmp = src.with_suffix(".jsonl.tmp")
+                with open(tmp, "w", encoding="utf-8") as f:
+                    for line in [*kept, *failed_lines]:
+                        f.write(line + "\n")
+                tmp.replace(src)
+            except OSError:
+                pass
 
-    return (archived, len(kept))
+        return (archived, len(kept) + len(failed_lines))
 
 
 def main() -> int:

--- a/.claude/scripts/guardrails_report.py
+++ b/.claude/scripts/guardrails_report.py
@@ -45,7 +45,7 @@ def _parse_ts(s: str) -> datetime | None:
         return None
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    return dt
+    return dt.astimezone(timezone.utc)
 
 
 def _iter_records(path: Path) -> Iterable[dict]:
@@ -195,7 +195,12 @@ def cmd_report(args: argparse.Namespace) -> int:
 
     if args.rule:
         print(f"### Top violations ({args.rule})")
-        recs_sorted = sorted(records, key=lambda r: r.get("ts", ""), reverse=True)
+        recs_sorted = sorted(
+            records,
+            key=lambda r: _parse_ts(r.get("ts", ""))
+            or datetime.min.replace(tzinfo=timezone.utc),
+            reverse=True,
+        )
         for i, rec in enumerate(recs_sorted[:20], 1):
             ts = rec.get("ts", "?")
             ctx = rec.get("ctx", {})

--- a/.claude/scripts/guardrails_report.py
+++ b/.claude/scripts/guardrails_report.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Aggregate and report guardrail violations from violations.jsonl.
+
+Used by:
+- .claude/hooks/session-start-guardrails.sh (--summary)
+- .claude/skills/guardrails-report (--report)
+
+Fail-open: any error → exit 0 with no output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
+
+GUARDRAIL_DIR = Path.home() / ".claude" / "guardrails"
+VIOLATIONS_FILE = GUARDRAIL_DIR / "violations.jsonl"
+ARCHIVE_DIR = GUARDRAIL_DIR / "archive"
+
+# Known rules (R-001..R-007). Used so summary lists all rules even when 0.
+KNOWN_RULES: list[tuple[str, str, str]] = [
+    ("R-001", "secrets", "block"),
+    ("R-002", "git-add-wild", "warn"),
+    ("R-003", "error-loop", "warn"),
+    ("R-004", "pre-git-check", "warn"),
+    ("R-005", "git-force", "block"),
+    ("R-006", "todo-commit", "warn"),
+    ("R-007", "test-skip", "warn"),
+]
+RULE_NAME = {rid: name for rid, name, _ in KNOWN_RULES}
+RULE_SEV = {rid: sev for rid, _, sev in KNOWN_RULES}
+
+
+def _parse_ts(s: str) -> datetime | None:
+    try:
+        dt = datetime.fromisoformat(s)
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _iter_records(path: Path) -> Iterable[dict]:
+    if not path.exists():
+        return
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return
+
+
+def _iter_archive(archive_dir: Path) -> Iterable[dict]:
+    if not archive_dir.exists():
+        return
+    try:
+        files = sorted(archive_dir.glob("violations-*.jsonl.gz"))
+    except OSError:
+        return
+    for fp in files:
+        try:
+            with gzip.open(fp, "rt", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        yield json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+        except OSError:
+            continue
+
+
+def _current_project() -> str:
+    cwd = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    return Path(cwd).name
+
+
+def load(
+    days: int,
+    project: str | None,
+    rule: str | None,
+    *,
+    include_archive: bool = False,
+    src: Path | None = None,
+    archive_dir: Path | None = None,
+    now: datetime | None = None,
+) -> list[dict]:
+    if src is None:
+        src = VIOLATIONS_FILE
+    if archive_dir is None:
+        archive_dir = ARCHIVE_DIR
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=days)
+    out: list[dict] = []
+    sources: list[Iterable[dict]] = [_iter_records(src)]
+    if include_archive:
+        sources.append(_iter_archive(archive_dir))
+    for it in sources:
+        for rec in it:
+            ts = _parse_ts(rec.get("ts", ""))
+            if ts is None or ts < cutoff:
+                continue
+            if project and project != "*" and rec.get("project") != project:
+                continue
+            if rule and rec.get("rule_id") != rule:
+                continue
+            out.append(rec)
+    return out
+
+
+def cmd_summary(args: argparse.Namespace) -> int:
+    project = None if args.all_projects else (args.project or _current_project())
+    records = load(args.days, project, None)
+    if not records:
+        return 0
+    counts: Counter[str] = Counter(r.get("rule_id", "?") for r in records)
+    proj_label = "all projects" if args.all_projects else (project or "current")
+    lines = [f"[Guardrails] Last {args.days} days in {proj_label}:"]
+    threshold = args.warn_threshold
+    for rid, name, _ in KNOWN_RULES:
+        n = counts.get(rid, 0)
+        marker = "  ← 要注意" if n >= threshold and n > 0 else ""
+        lines.append(f"  {rid} {name:<14} {n}{marker}")
+    extras = sorted(set(counts) - set(RULE_NAME))
+    for rid in extras:
+        n = counts[rid]
+        marker = "  ← 要注意" if n >= threshold else ""
+        lines.append(f"  {rid} (unknown)     {n}{marker}")
+    lines.append("")
+    lines.append("詳細: /guardrails:report")
+    print("\n".join(lines))
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    project = None if args.all_projects else (args.project or _current_project())
+    records = load(args.days, project, args.rule, include_archive=True)
+    proj_label = "all projects" if args.all_projects else (project or "current")
+    print(f"## Guardrails Report (last {args.days} days)")
+    print(f"Project: {proj_label}")
+    print()
+
+    if not records:
+        print("No violations.")
+        return 0
+
+    # Trend: compare to previous window of same length
+    prev_records = load(
+        args.days * 2,
+        project,
+        args.rule,
+        include_archive=True,
+    )
+    cutoff_recent = datetime.now(timezone.utc) - timedelta(days=args.days)
+    prev_only = [
+        r
+        for r in prev_records
+        if (_parse_ts(r.get("ts", "")) or datetime.now(timezone.utc)) < cutoff_recent
+    ]
+    prev_counts: Counter[str] = Counter(r.get("rule_id", "?") for r in prev_only)
+
+    counts: Counter[str] = Counter(r.get("rule_id", "?") for r in records)
+
+    print("### Summary")
+    print("| Rule | Count | Severity | Trend |")
+    print("|------|-------|----------|-------|")
+    for rid, _, sev in KNOWN_RULES:
+        n = counts.get(rid, 0)
+        if n == 0 and not args.rule:
+            continue
+        if args.rule and rid != args.rule:
+            continue
+        prev = prev_counts.get(rid, 0)
+        trend = _trend(n, prev)
+        print(f"| {rid} | {n} | {sev} | {trend} |")
+    print()
+
+    if args.rule:
+        print(f"### Top violations ({args.rule})")
+        recs_sorted = sorted(records, key=lambda r: r.get("ts", ""), reverse=True)
+        for i, rec in enumerate(recs_sorted[:20], 1):
+            ts = rec.get("ts", "?")
+            ctx = rec.get("ctx", {})
+            ctx_str = json.dumps(ctx, ensure_ascii=False) if ctx else ""
+            print(f"{i}. {ts} — {ctx_str}")
+        print()
+
+    print("### Recommendations")
+    by_rule = defaultdict(int)
+    for r in records:
+        by_rule[r.get("rule_id", "?")] += 1
+    recs = []
+    for rid, n in sorted(by_rule.items(), key=lambda x: -x[1]):
+        if n >= 5 and rid in RULE_NAME:
+            recs.append(
+                f"- {rid} ({RULE_NAME[rid]}) が {n}件発生。"
+                "再発防止のため自動チェック強化を検討。"
+            )
+    if not recs:
+        recs.append("- 大きな問題は検出されていません。")
+    print("\n".join(recs))
+    return 0
+
+
+def _trend(curr: int, prev: int) -> str:
+    if prev == 0 and curr == 0:
+        return "→"
+    if prev == 0:
+        return "↑↑" if curr >= 3 else "↑"
+    ratio = curr / prev
+    if ratio >= 2.0:
+        return "↑↑"
+    if ratio >= 1.2:
+        return "↑"
+    if ratio <= 0.5:
+        return "↓↓"
+    if ratio <= 0.8:
+        return "↓"
+    return "→"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(prog="guardrails_report")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("summary", help="SessionStart-style summary")
+    s.add_argument("--days", type=int, default=7)
+    s.add_argument("--project", default=None)
+    s.add_argument("--all-projects", action="store_true")
+    s.add_argument("--warn-threshold", type=int, default=2)
+    s.set_defaults(func=cmd_summary)
+
+    r = sub.add_parser("report", help="/guardrails:report markdown report")
+    r.add_argument("--days", type=int, default=7)
+    r.add_argument("--rule", default=None)
+    r.add_argument("--project", default=None)
+    r.add_argument("--all-projects", action="store_true")
+    r.set_defaults(func=cmd_report)
+
+    args = p.parse_args(argv)
+    try:
+        return args.func(args)
+    except Exception:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/session-start-guardrails.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.claude/skills/guardrails-report/SKILL.md
+++ b/.claude/skills/guardrails-report/SKILL.md
@@ -27,7 +27,7 @@ python3 "$CLAUDE_PROJECT_DIR/.claude/scripts/guardrails_report.py" report "$@"
 
 ## 出力例
 
-```
+```text
 ## Guardrails Report (last 7 days)
 Project: claude-context-manager
 

--- a/.claude/skills/guardrails-report/SKILL.md
+++ b/.claude/skills/guardrails-report/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: guardrails-report
+description: Display guardrail violations summary from ~/.claude/guardrails/violations.jsonl
+global: false
+tools: Bash
+model: sonnet
+---
+
+# /guardrails:report - ガードレール違反レポート
+
+## 概要
+Phase 2 で蓄積された `~/.claude/guardrails/violations.jsonl` を集計し、Markdown レポートとして表示します。
+
+## 引数
+- `--days N` 集計期間（デフォルト 7）
+- `--rule R-XXX` 特定ルールの詳細表示
+- `--project NAME` プロジェクト指定（デフォルト カレント）
+- `--all-projects` 全プロジェクト集計
+
+## 実行
+
+```bash
+python3 "$CLAUDE_PROJECT_DIR/.claude/scripts/guardrails_report.py" report "$@"
+```
+
+引数なしの場合は直近7日のサマリーをカレントプロジェクトで表示します。
+
+## 出力例
+
+```
+## Guardrails Report (last 7 days)
+Project: claude-context-manager
+
+### Summary
+| Rule | Count | Severity | Trend |
+|------|-------|----------|-------|
+| R-002 | 2 | warn | ↑ |
+| R-006 | 3 | warn | → |
+| R-007 | 5 | warn | ↑↑ |
+
+### Recommendations
+- R-007 (test-skip) が 5件発生。再発防止のため自動チェック強化を検討。
+```
+
+`--rule R-007` 指定時は該当ルールの直近20件の詳細リストも表示されます。
+
+アーカイブ済み（30日超）のデータも自動的に集計対象に含まれます。

--- a/src/hooks/guardrail_log.py
+++ b/src/hooks/guardrail_log.py
@@ -8,6 +8,7 @@ Fail-open: all errors are swallowed so hooks never break.
 
 from __future__ import annotations
 
+import fcntl
 import json
 from datetime import datetime
 from pathlib import Path
@@ -56,8 +57,22 @@ def write_violation(
             "ctx": ctx,
             "action": action,
         }
-        with open(path, "a", encoding="utf-8") as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        # Shared exclusive lock with archive_violations.py to prevent
+        # the archiver's read/rewrite cycle from losing concurrent appends.
+        lock_path = path.with_suffix(path.suffix + ".lock")
+        with open(lock_path, "w") as lock_fh:
+            try:
+                fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+            try:
+                with open(path, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            finally:
+                try:
+                    fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
         return True
     except (OSError, TypeError, ValueError):
         return False

--- a/tests/test_guardrails_surface.py
+++ b/tests/test_guardrails_surface.py
@@ -1,0 +1,164 @@
+"""AC tests for #131 Phase 3: B サーフェス."""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import json
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / ".claude" / "scripts"
+HOOK_SH = ROOT / ".claude" / "hooks" / "session-start-guardrails.sh"
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+report = _load("guardrails_report")
+archive_mod = _load("archive_violations")
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _rec(
+    rule_id: str, days_ago: float = 0, project: str = "claude-context-manager"
+) -> dict:
+    ts = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return {
+        "ts": ts.isoformat(timespec="seconds"),
+        "session_id": "test",
+        "project": project,
+        "rule_id": rule_id,
+        "severity": "warn",
+        "ctx": {"cmd": f"git commit ({rule_id})"},
+        "action": "logged",
+    }
+
+
+def test_ac1_summary_with_5_records(tmp_path, monkeypatch):
+    """AC-1: 5件の violations で SessionStart 集計が正しく表示される."""
+    src = tmp_path / "violations.jsonl"
+    recs = [_rec("R-007", 0.5)] * 5
+    _write_jsonl(src, recs)
+    monkeypatch.setattr(report, "VIOLATIONS_FILE", src)
+    monkeypatch.setattr(report, "ARCHIVE_DIR", tmp_path / "archive")
+    out = report.load(
+        7, "claude-context-manager", None, src=src, archive_dir=tmp_path / "archive"
+    )
+    assert len(out) == 5
+
+
+def test_ac2_zero_records_silent(tmp_path, monkeypatch, capsys):
+    """AC-2: 0件のとき何も出力しない."""
+    src = tmp_path / "violations.jsonl"
+    src.touch()
+    monkeypatch.setattr(report, "VIOLATIONS_FILE", src)
+    monkeypatch.setattr(report, "ARCHIVE_DIR", tmp_path / "archive")
+    rc = report.main(["summary", "--days", "7", "--project", "claude-context-manager"])
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out == ""
+
+
+def test_ac3_report_markdown(tmp_path, monkeypatch, capsys):
+    """AC-3: /guardrails:report が Markdown サマリーを返す."""
+    src = tmp_path / "violations.jsonl"
+    _write_jsonl(src, [_rec("R-002"), _rec("R-007"), _rec("R-007")])
+    monkeypatch.setattr(report, "VIOLATIONS_FILE", src)
+    monkeypatch.setattr(report, "ARCHIVE_DIR", tmp_path / "archive")
+    rc = report.main(["report", "--days", "7", "--project", "claude-context-manager"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "## Guardrails Report" in out
+    assert "| Rule | Count" in out
+    assert "R-007" in out
+
+
+def test_ac4_report_rule_detail(tmp_path, monkeypatch, capsys):
+    """AC-4: --rule R-007 で該当ルールの詳細リストが返る."""
+    src = tmp_path / "violations.jsonl"
+    _write_jsonl(src, [_rec("R-007", i * 0.1) for i in range(3)] + [_rec("R-002")])
+    monkeypatch.setattr(report, "VIOLATIONS_FILE", src)
+    monkeypatch.setattr(report, "ARCHIVE_DIR", tmp_path / "archive")
+    rc = report.main(
+        [
+            "report",
+            "--days",
+            "7",
+            "--rule",
+            "R-007",
+            "--project",
+            "claude-context-manager",
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Top violations (R-007)" in out
+    assert out.count("git commit (R-007)") == 3
+
+
+def test_ac5_archive_moves_old_entries(tmp_path):
+    """AC-5: 30日経過 entries が archive/ に移動、元ファイルから削除."""
+    src = tmp_path / "violations.jsonl"
+    recent = _rec("R-002", days_ago=1)
+    old = _rec("R-007", days_ago=45)
+    _write_jsonl(src, [recent, old])
+    archive_dir = tmp_path / "archive"
+    archived, kept = archive_mod.archive(
+        src=src, archive_dir=archive_dir, retention_days=30
+    )
+    assert archived == 1
+    assert kept == 1
+    remaining = src.read_text(encoding="utf-8").strip().splitlines()
+    assert len(remaining) == 1
+    assert "R-002" in remaining[0]
+
+
+def test_ac6_archive_is_gzipped(tmp_path):
+    """AC-6: アーカイブファイルが .gz 圧縮されている."""
+    src = tmp_path / "violations.jsonl"
+    _write_jsonl(src, [_rec("R-007", days_ago=60)])
+    archive_dir = tmp_path / "archive"
+    archive_mod.archive(src=src, archive_dir=archive_dir, retention_days=30)
+    files = list(archive_dir.glob("violations-*.jsonl.gz"))
+    assert len(files) == 1
+    with gzip.open(files[0], "rt", encoding="utf-8") as f:
+        line = f.readline()
+    assert "R-007" in line
+
+
+def test_ac7_hook_under_300ms(tmp_path, monkeypatch):
+    """AC-7: SessionStart hook 実行時間 < 300ms (空ファイル想定)."""
+    fake_home = tmp_path / "home"
+    (fake_home / ".claude" / "guardrails").mkdir(parents=True)
+    (fake_home / ".claude" / "guardrails" / "violations.jsonl").touch()
+    env = {"HOME": str(fake_home), "PATH": "/usr/bin:/bin:/usr/local/bin"}
+    # Warm-up to avoid measuring python first-import jitter
+    subprocess.run(["bash", str(HOOK_SH)], env=env, capture_output=True, check=False)
+    start = time.perf_counter()
+    subprocess.run(["bash", str(HOOK_SH)], env=env, capture_output=True, check=False)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert elapsed_ms < 300, f"hook took {elapsed_ms:.0f}ms"
+
+
+def test_archive_handles_missing_file(tmp_path):
+    """Fail-open: missing source file → (0,0)."""
+    archived, kept = archive_mod.archive(
+        src=tmp_path / "nope.jsonl", archive_dir=tmp_path / "a", retention_days=30
+    )
+    assert (archived, kept) == (0, 0)


### PR DESCRIPTION
## Summary
- SessionStart hook で violations.jsonl の直近7日サマリーを表示（0件は無音）
- `/guardrails:report` skill で Markdown レポート（トレンド・ルール別詳細対応）
- 30日超エントリを月次 `.gz` アーカイブに移動

## AC
| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | 5件で集計表示 | PASS |
| AC-2 | 0件で無音 | PASS |
| AC-3 | report Markdown | PASS |
| AC-4 | --rule 詳細 | PASS |
| AC-5 | 30日超アーカイブ移動 | PASS |
| AC-6 | .gz 圧縮 | PASS |
| AC-7 | hook < 300ms | PASS |

## Test plan
- [x] `pytest tests/test_guardrails_surface.py` 全PASS（8/8）

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  - ガードレール違反の集計レポート表示機能を追加。期間指定やルール絞込、Markdownレポート出力に対応
  - 古い違反記録を月別に圧縮アーカイブする自動処理を追加
  - セッション開始時に関連処理を自動実行するフックを追加

* **バグ修正／信頼性**
  - 書き込み時の競合を軽減する排他制御を追加（データ損失を防止）

* **ドキュメント**
  - レポート機能の利用方法を記載したスキル説明を追加

* **テスト**
  - エンドツーエンドの動作検証テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->