### PR TITLE
fix: summary-bot の LLM を GitHub Models から Gemini API へ差し替える (#152)

### DIFF
--- a/.github/workflows/summary-bot.yml
+++ b/.github/workflows/summary-bot.yml
@@ -1,5 +1,16 @@
 name: Summary Bot
 
+# Issue / PR が開かれたら、内容を要約したポエムをコメントする。
+#
+# LLM は Google AI Studio の Gemini API（Flash 系は無料枠）を使う。
+# 以前は actions/ai-inference + GitHub Models だったが、GitHub Models が廃止過程
+# （scheduled retirement brownout）に入り 410 を返すようになり、本ジョブは 2026-08 以降
+# 何も投稿しない死んだ状態だった（Issue #152）。actions/ai-inference@v1 自体も
+# provider が Copilot CLI 専用へ移行しており、runner 上に認証済み Copilot CLI を
+# 要求するため代替にならない。よって API を直接叩く形に変更した。
+#
+# 必要な secret: GEMINI_API_KEY（Qodo pr-agent と共用）
+
 on:
   issues:
     types: [opened]
@@ -9,56 +20,85 @@ on:
 permissions:
   issues: write
   pull-requests: write
-  models: read
   contents: read
 
 jobs:
   summarize:
     runs-on: ubuntu-latest
+    # 要約は付加価値であり、失敗しても本体の CI を妨げない
     continue-on-error: true
     steps:
       - name: Generate poem summary
         id: ai
-        uses: actions/ai-inference@v1
-        with:
-          model: openai/gpt-4o-mini
-          max-tokens: 300
-          system-prompt: |
-            あなたは GitHub Issue/PR を読んで情報密度の高いポエム調要約を書くボットです。
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          # ${{ }} を run: の中へ直接展開するとスクリプトインジェクションになるため env 経由で渡す
+          TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          BODY: ${{ github.event.issue.body || github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
 
-            要件:
-            - 3〜6行で書く
-            - 何の問題/機能か、原因や対策など具体的な事実を必ず含める
-            - ポエム調・詩的なリズムで書く（比喩OKだが内容は具体的に）
-            - 読んだ人が「何の話か」が30秒でわかるレベルの情報量
-            - 日本語で書く
-            - 要約のみを出力し、前置きや説明は不要
+          if [ -z "${GEMINI_API_KEY:-}" ]; then
+            echo "::error::GEMINI_API_KEY secret is not set" >&2
+            exit 1
+          fi
 
-            良い例（日本語文字化けIssueの場合）:
-            ひらがなが+0x90オフセットでカタカナへ化ける怪、
-            IMEカーソルが日本語を飲み込む二つの罪。
-            accessibilitySupport設定で静めながら、
-            根本原因は闇の中、観察続ける。
-          prompt: |
-            タイトル: ${{ github.event.issue.title || github.event.pull_request.title }}
+          SYSTEM_PROMPT='あなたは GitHub Issue/PR を読んで情報密度の高いポエム調要約を書くボットです。
 
-            本文:
-            ${{ github.event.issue.body || github.event.pull_request.body }}
+          要件:
+          - 3〜6行で書く
+          - 何の問題/機能か、原因や対策など具体的な事実を必ず含める
+          - ポエム調・詩的なリズムで書く（比喩OKだが内容は具体的に）
+          - 読んだ人が「何の話か」が30秒でわかるレベルの情報量
+          - 日本語で書く
+          - 要約のみを出力し、前置きや説明は不要
+
+          良い例（日本語文字化けIssueの場合）:
+          ひらがなが+0x90オフセットでカタカナへ化ける怪、
+          IMEカーソルが日本語を飲み込む二つの罪。
+          accessibilitySupport設定で静めながら、
+          根本原因は闇の中、観察続ける。'
+
+          # 本文は長くなりうるので先頭 8000 文字に制限する（無料枠のトークン節約）
+          jq -n \
+            --arg system "$SYSTEM_PROMPT" \
+            --arg user "タイトル: ${TITLE}"$'\n\n'"本文:"$'\n'"$(printf '%s' "${BODY:-}" | head -c 8000)" \
+            '{
+               system_instruction: { parts: [ { text: $system } ] },
+               contents: [ { parts: [ { text: $user } ] } ],
+               generationConfig: { maxOutputTokens: 1024 }
+             }' > request.json
+
+          # gemini-3.7-flash は thinking にトークンを使うため maxOutputTokens に余裕を持たせる
+          # （2.5-flash は 300 だと finishReason=MAX_TOKENS で途中で切れることを実測済み）
+          HTTP_CODE=$(curl -sS -o response.json -w '%{http_code}' \
+            -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent?key=${GEMINI_API_KEY}" \
+            -H 'Content-Type: application/json' \
+            --data @request.json)
+
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Gemini API returned HTTP ${HTTP_CODE}" >&2
+            jq -r '.error.message // "no error message"' response.json >&2
+            exit 1
+          fi
+
+          FINISH=$(jq -r '.candidates[0].finishReason // "UNKNOWN"' response.json)
+          jq -r '.candidates[0].content.parts[0].text // ""' response.json > poem.txt
+
+          if [ "$FINISH" != "STOP" ] || [ ! -s poem.txt ]; then
+            echo "::error::unusable response (finishReason=${FINISH}, bytes=$(wc -c < poem.txt))" >&2
+            exit 1
+          fi
 
       - name: Post poem as comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-          RESPONSE: ${{ steps.ai.outputs.response }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if [ -z "${RESPONSE:-}" ]; then
-            echo "ai-inference returned empty response; skipping comment"
-            exit 0
-          fi
           {
             echo "> 🎭 *AIポエムサマリー*"
             echo ">"
-            printf '%s\n' "$RESPONSE" | sed 's/^/> /'
+            sed 's/^/> /' poem.txt
           } | gh issue comment "$NUMBER" --repo "$REPO" --body-file -

--- a/.github/workflows/summary-bot.yml
+++ b/.github/workflows/summary-bot.yml
@@ -25,8 +25,16 @@ permissions:
 jobs:
   summarize:
     runs-on: ubuntu-latest
+    # fork からの PR には repository secret が渡らないため、無駄に赤くせずスキップする。
+    # secrets context は jobs.<job_id>.if では参照できない仕様のため github context で判定する
+    # https://docs.github.com/en/actions/reference/workflows-and-actions/contexts
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     # 要約は付加価値であり、失敗しても本体の CI を妨げない
     continue-on-error: true
+    # API / ネットワークが停滞しても runner を長時間占有しない
+    timeout-minutes: 5
     steps:
       - name: Generate poem summary
         id: ai
@@ -59,19 +67,25 @@ jobs:
           accessibilitySupport設定で静めながら、
           根本原因は闇の中、観察続ける。'
 
-          # 本文は長くなりうるので先頭 8000 文字に制限する（無料枠のトークン節約）
+          # 本文は長くなりうるので先頭 8000 文字に制限する（無料枠のトークン節約）。
+          # 切り詰めは jq の文字列スライスで行う。`head -c` はバイト単位で切るため、
+          # 日本語では文字数が合わないうえ UTF-8 のマルチバイト文字を途中で分断しうる
           jq -n \
             --arg system "$SYSTEM_PROMPT" \
-            --arg user "タイトル: ${TITLE}"$'\n\n'"本文:"$'\n'"$(printf '%s' "${BODY:-}" | head -c 8000)" \
+            --arg title "$TITLE" \
+            --arg body "${BODY:-}" \
             '{
                system_instruction: { parts: [ { text: $system } ] },
-               contents: [ { parts: [ { text: $user } ] } ],
+               contents: [ { parts: [ {
+                 text: ("タイトル: " + $title + "\n\n本文:\n" + $body[0:8000])
+               } ] } ],
                generationConfig: { maxOutputTokens: 1024 }
              }' > request.json
 
           # gemini-3.7-flash は thinking にトークンを使うため maxOutputTokens に余裕を持たせる
           # （2.5-flash は 300 だと finishReason=MAX_TOKENS で途中で切れることを実測済み）
           HTTP_CODE=$(curl -sS -o response.json -w '%{http_code}' \
+            --connect-timeout 10 --max-time 120 --retry 2 --retry-connrefused \
             -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.7-flash:generateContent?key=${GEMINI_API_KEY}" \
             -H 'Content-Type: application/json' \
             --data @request.json)


### PR DESCRIPTION
Closes #152

## 背景

`.github/workflows/summary-bot.yml` の `summarize` job が `410 GitHub Models is temporarily unavailable as part of a scheduled retirement brownout` で失敗している。

このため **2026-08 以降ポエム要約は一度も投稿されていない**。Issue #152 自身が `issues: opened` で本 workflow を起動しているが（run `32101964896`、conclusion=success）、コメントは 0 件だった。`continue-on-error: true` により run 全体は success を返すため、機能が死んでいることが表面化していなかった。

PR 側では `summarize` の check-run だけが FAILURE として残り続ける（PR #151 で観測）。

## 当初案からの変更

Issue #152 では「Qodo pr-agent が PR 要約を担うようになったので **A: 削除**」を推奨していたが、実装前の調査で前提が誤っていたことが判明したため **B: LLM プロバイダ差し替え** に変更する。

| # | 当初の想定 | 実際 |
|---|---|---|
| 1 | Qodo / CodeRabbit と機能が重複 | 本 workflow は **`issues: opened` も対象**。Issue にコメントするボットは他に無く、重複していない |
| 2 | PR 要約ボット | 実体は**ポエム調要約**という別物。Qodo の技術要約では代替されない |
| 3 | `actions/ai-inference` の provider 差し替えで延命できる | 同 action は provider が **Copilot CLI 専用**へ移行済み（`action.yml` の `provider` input: `Only "copilot" is supported`）。runner 上に認証済み Copilot CLI を要求するため代替にならない |

## 変更内容

`actions/ai-inference` をやめ、Gemini API を直接呼ぶ。認証は Qodo pr-agent (#151) で登録済みの `GEMINI_API_KEY` を再利用するため、**新規 secret の登録は不要**。

- **model**: `gemini-3.7-flash`（Flash 系は無料枠）
- **maxOutputTokens**: 1024。gemini-3.7-flash は thinking にトークンを使うため余裕を持たせる
- **セキュリティ**: title / body は `env:` 経由で渡し、`run:` へ `${{ }}` を直接展開しない（スクリプトインジェクション対策）。不要になった `models: read` 権限を削除
- **サイレント失敗の禁止**: HTTP status / `finishReason` / 空文字を検査し、異常時は投稿せず error で落とす（空コメントを出さない）
- ポエムのプロンプト・出力形式は従来どおり維持

## 検証

### 事前実測（ローカル）

workflow の `run:` ブロックを抽出して実キーで実行し、投稿本文まで生成されることを確認済み。

```
$ ruby -ryaml -e 'print YAML.load_file(ARGV[0])["jobs"]["summarize"]["steps"][0]["run"]' \
    .github/workflows/summary-bot.yml > step1.sh
$ TITLE=... BODY=... npx dotenv-cli -e ~/.claude/.env -- bash step1.sh
$ echo $?
0
$ cat poem.txt
声なき 410 Gone、廃止の黄昏に沈む GitHub Models、
actions/ai-inference が叩く models.github.ai は冷たく途絶え、
summary-bot の CI パイプラインを無慈悲に赤く染め上げる。
実績ある Qodo の光を借り、Gemini API 無料枠へと舵を切り、
途切れた要約の息吹をふたたび巡らせる。
```

モデル選定も実測している。`gemini-2.5-flash` + `maxOutputTokens: 300` は `finishReason=MAX_TOKENS` で途中で切れ、`gemini-3.7-flash` は `STOP` で完走した。

### 統合ジャーニーAC

| # | 操作 | 期待結果 | 検証手段 |
|---|---|---|---|
| 1 | 本 PR を open する（`pull_request: opened`） | `summarize` check が SUCCESS になる | `gh pr view --json statusCheckRollup` |
| 2 | 同上 | 本 PR に「🎭 AIポエムサマリー」コメントが付く | `gh pr view --json comments` |
| 3 | merge 後に Issue を open する | Issue にポエムコメントが付く | 次回 Issue 起票時に確認 |

**本 PR 自身が AC-1 / AC-2 の実証になる**（同一リポジトリの PR では head 側の workflow ファイルが使われるため）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **機能改善**
  - Issueやプルリクエストのタイトル・本文をもとに、AIによる要約コメントを自動生成・投稿する仕組みを改善しました。
  - 要約内容や応答状態を確認し、正常に生成された要約のみ投稿するようになりました。
  - 必要な設定が不足している場合や処理に失敗した場合も、安全に処理を終了します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->